### PR TITLE
feat(accountingservice): add LocalPfxPath fallback + idempotent cert upload

### DIFF
--- a/scripts/new-cert.ps1
+++ b/scripts/new-cert.ps1
@@ -24,7 +24,15 @@ Export-Certificate    -Cert $cert -FilePath $cer | Out-Null
 $appId = az ad app list --display-name $AppName --query '[0].appId' -o tsv
 if (-not $appId) { throw "App '$AppName' not found — run setup-entra.ps1 first." }
 
-az ad app credential reset --id $appId --cert "@$cer" --append | Out-Null
+$thumb = $cert.Thumbprint.ToLower()
+$existing = az ad app credential list --id $appId `
+    --query "[?customKeyIdentifier!=null] | [?ends_with(tolower(customKeyIdentifier), '$thumb')]" -o tsv
+
+if ($existing) {
+    Write-Host "==> Cert with thumbprint $thumb already attached to $AppName — skipping upload."
+} else {
+    az ad app credential reset --id $appId --cert "@$cer" --append | Out-Null
+}
 
 Write-Host "PFX:        $pfx"
 Write-Host "Thumbprint: $($cert.Thumbprint.ToLower())"

--- a/scripts/new-cert.sh
+++ b/scripts/new-cert.sh
@@ -34,8 +34,16 @@ THUMB=$(openssl x509 -in "$CRT" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d 
 APP_ID=$(az ad app list --display-name "$APP_NAME" --query "[0].appId" -o tsv)
 [[ -z "$APP_ID" ]] && { echo "ERROR: app '$APP_NAME' not found. Run scripts/setup-entra.sh first." >&2; exit 1; }
 
-echo "==> Uploading public key to app registration ($APP_NAME / $APP_ID)"
-az ad app credential reset --id "$APP_ID" --cert "@${CRT}" --append >/dev/null
+EXISTING=$(az ad app credential list --id "$APP_ID" \
+  --query "[?customKeyIdentifier!=null] | [?ends_with(tolower(customKeyIdentifier), '${THUMB}')]" \
+  -o tsv 2>/dev/null || true)
+
+if [[ -n "$EXISTING" ]]; then
+  echo "==> Cert with thumbprint $THUMB already attached to $APP_NAME — skipping upload."
+else
+  echo "==> Uploading public key to app registration ($APP_NAME / $APP_ID)"
+  az ad app credential reset --id "$APP_ID" --cert "@${CRT}" --append >/dev/null
+fi
 
 echo
 echo "============================================================"

--- a/src/Ftgo.AccountingService/CertificateTokenProvider.cs
+++ b/src/Ftgo.AccountingService/CertificateTokenProvider.cs
@@ -15,13 +15,27 @@ internal sealed class AzureAdOptions
 
 internal sealed class KeyVaultCertOptions
 {
-    [Required, Url] public string Uri { get; init; } = string.Empty;
-    [Required] public string CertName { get; init; } = string.Empty;
+    [Url] public string? Uri { get; init; }
+
+    public string? CertName { get; init; }
 
     /// <summary>
     /// Optional user-assigned managed identity client ID. Leave empty to use system-assigned MI.
     /// </summary>
     public string? ManagedIdentityClientId { get; init; }
+
+    /// <summary>
+    /// Optional path to a local PFX file. When set, the certificate is loaded from disk and
+    /// Key Vault is bypassed entirely — useful for local development without a Key Vault.
+    /// In production this should be left null so the cert is pulled from Key Vault using
+    /// managed identity.
+    /// </summary>
+    public string? LocalPfxPath { get; init; }
+
+    /// <summary>
+    /// Optional passphrase for <see cref="LocalPfxPath"/>. Empty string is treated as no passphrase.
+    /// </summary>
+    public string? LocalPfxPassword { get; init; }
 }
 
 /// <summary>
@@ -50,20 +64,9 @@ internal sealed partial class CertificateTokenProvider : IAppTokenProvider, IHos
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        var credential = string.IsNullOrWhiteSpace(_kv.Value.ManagedIdentityClientId)
-            ? new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned)
-            : new ManagedIdentityCredential(
-                ManagedIdentityId.FromUserAssignedClientId(_kv.Value.ManagedIdentityClientId));
-
-        var certClient = new CertificateClient(new Uri(_kv.Value.Uri), credential);
-        var downloaded = await certClient.DownloadCertificateAsync(
-            new DownloadCertificateOptions(_kv.Value.CertName)
-            {
-                KeyStorageFlags = X509KeyStorageFlags.EphemeralKeySet,
-            },
-            cancellationToken).ConfigureAwait(false);
-
-        _certificate = downloaded.Value;
+        _certificate = !string.IsNullOrWhiteSpace(_kv.Value.LocalPfxPath)
+            ? LoadFromLocalPfx(_kv.Value)
+            : await LoadFromKeyVaultAsync(_kv.Value, cancellationToken).ConfigureAwait(false);
 
         _app = ConfidentialClientApplicationBuilder
             .Create(_aad.Value.ClientId)
@@ -71,7 +74,41 @@ internal sealed partial class CertificateTokenProvider : IAppTokenProvider, IHos
             .WithCertificate(_certificate)
             .Build();
 
-        LogCertLoaded(_kv.Value.CertName);
+        LogCertLoaded(_kv.Value.LocalPfxPath ?? _kv.Value.CertName ?? string.Empty);
+    }
+
+    private static X509Certificate2 LoadFromLocalPfx(KeyVaultCertOptions kv)
+    {
+        var path = kv.LocalPfxPath!;
+        var bytes = File.ReadAllBytes(path);
+        return X509CertificateLoader.LoadPkcs12(
+            bytes,
+            kv.LocalPfxPassword,
+            X509KeyStorageFlags.EphemeralKeySet);
+    }
+
+    private static async Task<X509Certificate2> LoadFromKeyVaultAsync(KeyVaultCertOptions kv, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(kv.Uri) || string.IsNullOrWhiteSpace(kv.CertName))
+        {
+            throw new InvalidOperationException(
+                "KeyVault:Uri and KeyVault:CertName are required when KeyVault:LocalPfxPath is not set.");
+        }
+
+        var credential = string.IsNullOrWhiteSpace(kv.ManagedIdentityClientId)
+            ? new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned)
+            : new ManagedIdentityCredential(
+                ManagedIdentityId.FromUserAssignedClientId(kv.ManagedIdentityClientId));
+
+        var certClient = new CertificateClient(new Uri(kv.Uri), credential);
+        var downloaded = await certClient.DownloadCertificateAsync(
+            new DownloadCertificateOptions(kv.CertName)
+            {
+                KeyStorageFlags = X509KeyStorageFlags.EphemeralKeySet,
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return downloaded.Value;
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/Ftgo.AccountingService/Program.cs
+++ b/src/Ftgo.AccountingService/Program.cs
@@ -13,6 +13,10 @@ builder.Services
     .AddOptions<KeyVaultCertOptions>()
     .Bind(builder.Configuration.GetSection("KeyVault"))
     .ValidateDataAnnotations()
+    .Validate(
+        kv => !string.IsNullOrWhiteSpace(kv.LocalPfxPath)
+              || (!string.IsNullOrWhiteSpace(kv.Uri) && !string.IsNullOrWhiteSpace(kv.CertName)),
+        "KeyVault must set either LocalPfxPath (local dev) OR both Uri and CertName (Key Vault).")
     .ValidateOnStart();
 
 builder.Services.Configure<DownstreamApiOptions>(


### PR DESCRIPTION
CertificateTokenProvider now accepts an optional KeyVault:LocalPfxPath
(plus optional KeyVault:LocalPfxPassword). When set, the certificate is
loaded from disk via X509CertificateLoader.LoadPkcs12 with EphemeralKeySet
and Key Vault is bypassed entirely — closing the doc/code drift in
docs/run-locally.md, where the AccountingService row already implied a
file-path option that didn't exist.

KeyVault:Uri and KeyVault:CertName lose their [Required] data annotations;
a custom Validate(...) call in Program.cs enforces that EITHER LocalPfxPath
OR (Uri AND CertName) is provided, so production deployments still fail
fast at host start if mis-configured.

scripts/new-cert.sh and new-cert.ps1 now query the app registration's
existing credentials by thumbprint before calling 'az ad app credential
reset --append', so re-running the script no longer attaches a duplicate
credential each time (the script header already advertised it as safe to
re-run).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
