### PR TITLE
docs: fix gateway scope wording, cert local-dev steps, blob URL placeholder; xmldoc IAppTokenProvider

### DIFF
--- a/docs/acquisition.md
+++ b/docs/acquisition.md
@@ -29,7 +29,7 @@ var cred = new ManagedIdentityCredential();
 var cred = new ManagedIdentityCredential(
     ManagedIdentityId.FromUserAssignedClientId("<client-id>"));
 
-var blob = new BlobServiceClient(new Uri("https://acct.blob.core.windows.net"), cred);
+var blob = new BlobServiceClient(new Uri("https://<storage>.blob.core.windows.net"), cred);
 ```
 
 **Calling your own protected Web API with MI** — you need an actual JWT, two options:

--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -71,7 +71,7 @@ curl -k -H "Authorization: Bearer $TOKEN" https://localhost:7101/api/checkout/vi
 | Worker                       | How to run for free                                                                 |
 |------------------------------|--------------------------------------------------------------------------------------|
 | **Ftgo.KitchenService** (MI) | Locally `az login` makes `DefaultAzureCredential` work; in production this is MI.   |
-| **Ftgo.AccountingService** (cert) | `scripts/new-cert.sh` already created the .pfx and uploaded the public key. The worker reads it from Key Vault in prod; for local you can wire it to a file path via user-secrets. |
+| **Ftgo.AccountingService** (cert) | `scripts/new-cert.sh` creates the .pfx and uploads the public key. In prod the worker reads it from Key Vault via managed identity; for local dev set `KeyVault:LocalPfxPath` (and optionally `KeyVault:LocalPfxPassword`) in user-secrets to point at the .pfx — Key Vault is then bypassed entirely. |
 | **Ftgo.DeliveryService** (FIC)   | Run the GitHub Actions workflow `.github/workflows/wi-demo.yml` — it logs in via OIDC and acquires a token, no secret. |
 | **Ftgo.NotificationService** (secret) | `dotnet user-secrets set` the secret. Included as the **anti-pattern** for contrast — don't adopt this in real systems. |
 

--- a/docs/sample-setup.md
+++ b/docs/sample-setup.md
@@ -26,7 +26,7 @@ auth shapes are taught against recognisable, business-meaningful names.
 Create seven app registrations (the `scripts/setup-entra.{ps1,sh}` helpers
 do this idempotently — see `run-locally.md`):
 
-1. **ftgo-apigateway** (single-tenant) — exposes scope `orders.read`.
+1. **ftgo-apigateway** (single-tenant) — consumes the `orders.read` delegated scope on behalf of users.
 2. **ftgo-orderservice** (single-tenant) — exposes scope `orders.read` and app role `Orders.Process`.
 3. **ftgo-restaurantservice** (multi-tenant, `signInAudience: AzureADMultipleOrgs`) — exposes app role `Restaurants.Read.All`.
 4. **ftgo-kitchenservice** (single-tenant, optional) — only needed if running outside Azure; in Azure the identity is a **Managed Identity**.

--- a/src/Ftgo.Auth.Client/DownstreamApiClient.cs
+++ b/src/Ftgo.Auth.Client/DownstreamApiClient.cs
@@ -9,6 +9,15 @@ namespace Ftgo.Auth;
 /// </summary>
 public interface IAppTokenProvider
 {
+    /// <summary>
+    /// Acquires an app-only access token for the supplied scope.
+    /// </summary>
+    /// <param name="scope">
+    /// Fully-qualified resource scope (typically <c>{api-app-id-uri}/.default</c> for
+    /// client-credentials flows). Must not be null or empty.
+    /// </param>
+    /// <param name="cancellationToken">Token to cancel the underlying credential call.</param>
+    /// <returns>A bearer access token suitable for the <c>Authorization</c> header.</returns>
     ValueTask<string> GetAccessTokenAsync(string scope, CancellationToken cancellationToken);
 }
 


### PR DESCRIPTION
- docs/sample-setup.md: ftgo-apigateway *consumes* delegated 'orders.read'
  (the OrderService exposes it); fix the inverted wording.
- docs/run-locally.md: AccountingService row now matches the code — point
  KeyVault:LocalPfxPath at the .pfx via user-secrets to bypass Key Vault
  for local dev (lands alongside the new LocalPfxPath option).
- docs/acquisition.md: replace the look-real 'acct.blob.core.windows.net'
  hostname with '<storage>.blob.core.windows.net' so the snippet reads as
  a placeholder and not a leaked tenant artefact.
- IAppTokenProvider: add <param>/<returns> XML docs so consumers see the
  scope contract and cancellation semantics in IntelliSense.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
