### PR TITLE
feat(deploy): multi-env cloud deployment (dev/ppe/prod) on free-tier ACA

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Build / cache artifacts
+**/bin/
+**/obj/
+**/.vs/
+**/.vscode/
+**/.idea/
+.git/
+.github/
+.gitignore
+.gitattributes
+
+# Local dev runtime
+.logs/
+.certs/
+
+# Compiled IaC ARM output
+infra/bicep/main.json
+infra/bicep/*.json
+
+# Docs / scripts not needed at build time
+docs/
+README.md
+LICENSE
+CONTRIBUTING.md
+SECURITY.md
+*.md
+
+# Tests aren't part of the runtime image
+tests/
+
+# Misc
+**/*.pfx
+**/*.key
+**/*.pem
+**/.env
+**/.env.*
+**/appsettings.*.local.json
+TestResults/
+coverage/

--- a/.github/workflows/cd-cleanup.yml
+++ b/.github/workflows/cd-cleanup.yml
@@ -1,0 +1,54 @@
+# Cloud env safety net: nightly scale dev/ppe container apps to min=0/max=3 so a misconfigured
+# bicepparam (or manual `az` poke) can't keep instances pinned overnight and rack up bills.
+# Idempotent. Skips prod intentionally.
+name: cd-cleanup
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scale-down:
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev, ppe]
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Reset min/max replicas in rg-ftgo-${{ matrix.env }}-eastus
+        run: |
+          set -euo pipefail
+          RG="rg-ftgo-${{ matrix.env }}-eastus"
+          if ! az group show --name "$RG" --only-show-errors --output none 2>/dev/null; then
+            echo "Resource group $RG does not exist — skipping."
+            exit 0
+          fi
+          APPS=$(az containerapp list --resource-group "$RG" --query '[].name' -o tsv --only-show-errors)
+          if [ -z "$APPS" ]; then
+            echo "No container apps in $RG — skipping."
+            exit 0
+          fi
+          for app in $APPS; do
+            echo "Scaling $app → min=0 max=3"
+            az containerapp update \
+              --name "$app" \
+              --resource-group "$RG" \
+              --min-replicas 0 \
+              --max-replicas 3 \
+              --only-show-errors \
+              --output none
+          done

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,315 @@
+# Cloud CD pipeline: builds the 7 FTGO service images, pushes to GHCR, and rolls them
+# through dev → ppe → prod environments by deploying infra/bicep/azure.bicep (subscription scope)
+# and infra/bicep/main.bicep (tenant scope). OIDC-only auth — no client secrets.
+#
+# Environment GitHub vars expected per env: AZURE_CLIENT_ID, AZURE_SUBSCRIPTION_ID
+# Repo-level secret expected: AZURE_TENANT_ID
+# Bootstrap with scripts/bootstrap-env.sh ENV=<env>.
+name: cd
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment (dev|ppe|prod). Defaults to full dev→ppe→prod chain.
+        required: false
+        default: dev
+        type: choice
+        options: [dev, ppe, prod]
+      imageTag:
+        description: Existing image tag (e.g. sha-abc1234) to redeploy. Leave blank to build a fresh one from HEAD.
+        required: false
+        default: ''
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-images:
+    if: github.event_name == 'push' || github.event.inputs.imageTag == ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - Ftgo.ApiGateway
+          - Ftgo.OrderService
+          - Ftgo.RestaurantService
+          - Ftgo.KitchenService
+          - Ftgo.AccountingService
+          - Ftgo.DeliveryService
+          - Ftgo.NotificationService
+    outputs:
+      imageTag: ${{ steps.meta.outputs.imageTag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute image metadata
+        id: meta
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          PROJECT="${{ matrix.project }}"
+          # Strip "Ftgo." prefix and lowercase → "orderservice"
+          SHORT_NAME="${PROJECT#Ftgo.}"
+          SHORT_NAME="${SHORT_NAME,,}"
+          BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          {
+            echo "SHORT_SHA=${SHORT_SHA}"
+            echo "SHORT_NAME=${SHORT_NAME}"
+            echo "BUILD_TIMESTAMP=${BUILD_TIMESTAMP}"
+            echo "imageTag=sha-${SHORT_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push ${{ matrix.project }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          provenance: false
+          build-args: |
+            PROJECT=${{ matrix.project }}
+            BUILD_GIT_SHA=${{ github.sha }}
+            BUILD_VERSION=0.0.0-sha-${{ steps.meta.outputs.SHORT_SHA }}
+            BUILD_TIMESTAMP=${{ steps.meta.outputs.BUILD_TIMESTAMP }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/ftgo-${{ steps.meta.outputs.SHORT_NAME }}:sha-${{ steps.meta.outputs.SHORT_SHA }}
+            ghcr.io/${{ github.repository_owner }}/ftgo-${{ steps.meta.outputs.SHORT_NAME }}:latest
+          cache-from: type=gha,scope=ftgo-${{ steps.meta.outputs.SHORT_NAME }}
+          cache-to: type=gha,scope=ftgo-${{ steps.meta.outputs.SHORT_NAME }},mode=max
+
+  deploy-dev:
+    needs: build-images
+    if: |
+      always() &&
+      (needs.build-images.result == 'success' || needs.build-images.result == 'skipped') &&
+      (github.event_name == 'push' ||
+       github.event.inputs.environment == 'dev' ||
+       github.event.inputs.environment == 'ppe' ||
+       github.event.inputs.environment == 'prod')
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      scalar_url: ${{ steps.deploy.outputs.scalar_url }}
+      apigateway_fqdn: ${{ steps.deploy.outputs.apigateway_fqdn }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          TAG="${{ github.event.inputs.imageTag }}"
+          if [ -z "$TAG" ]; then
+            TAG="${{ needs.build-images.outputs.imageTag }}"
+          fi
+          if [ -z "$TAG" ]; then
+            TAG="sha-${GITHUB_SHA::7}"
+          fi
+          echo "imageTag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy infra (azure.bicep — dev)
+        id: deploy
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.imageTag }}
+        run: |
+          set -euo pipefail
+          NAME="ftgo-dev-$(date -u +%Y%m%d%H%M%S)"
+          az deployment sub create \
+            --location eastus \
+            --template-file infra/bicep/azure.bicep \
+            --parameters infra/bicep/azure.dev.bicepparam \
+            --parameters imageTag="${IMAGE_TAG}" \
+            --name "$NAME" \
+            --only-show-errors \
+            --output none
+          OUTPUTS=$(az deployment sub show --name "$NAME" --query properties.outputs -o json)
+          AGW_FQDN=$(echo "$OUTPUTS" | jq -r '.apiGatewayFqdn.value')
+          SCALAR_URL=$(echo "$OUTPUTS" | jq -r '.scalarUrl.value')
+          AGW_REDIRECT=$(echo "$OUTPUTS" | jq -r '.apiGatewayRedirectUri.value')
+          {
+            echo "apigateway_fqdn=${AGW_FQDN}"
+            echo "scalar_url=${SCALAR_URL}"
+            echo "apigateway_redirect=${AGW_REDIRECT}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Job summary
+        run: |
+          {
+            echo "## dev deployed"
+            echo "- Image tag: \`${{ steps.tag.outputs.imageTag }}\`"
+            echo "- Scalar: ${{ steps.deploy.outputs.scalar_url }}"
+            echo "- BFF: https://${{ steps.deploy.outputs.apigateway_fqdn }}"
+            echo ""
+            echo "_Entra app regs are provisioned out-of-band via_ \`scripts/provision-apps.sh ENV=dev\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy-ppe:
+    needs: [build-images, deploy-dev]
+    if: |
+      always() && needs.deploy-dev.result == 'success' &&
+      (github.event_name == 'push' ||
+       github.event.inputs.environment == 'ppe' ||
+       github.event.inputs.environment == 'prod')
+    runs-on: ubuntu-latest
+    environment: ppe
+    concurrency:
+      group: ppe
+      cancel-in-progress: false
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      scalar_url: ${{ steps.deploy.outputs.scalar_url }}
+      apigateway_fqdn: ${{ steps.deploy.outputs.apigateway_fqdn }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          TAG="${{ github.event.inputs.imageTag }}"
+          if [ -z "$TAG" ]; then
+            TAG="${{ needs.build-images.outputs.imageTag }}"
+          fi
+          if [ -z "$TAG" ]; then
+            TAG="sha-${GITHUB_SHA::7}"
+          fi
+          echo "imageTag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy infra (azure.bicep — ppe)
+        id: deploy
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.imageTag }}
+        run: |
+          set -euo pipefail
+          NAME="ftgo-ppe-$(date -u +%Y%m%d%H%M%S)"
+          az deployment sub create \
+            --location eastus \
+            --template-file infra/bicep/azure.bicep \
+            --parameters infra/bicep/azure.ppe.bicepparam \
+            --parameters imageTag="${IMAGE_TAG}" \
+            --name "$NAME" \
+            --only-show-errors \
+            --output none
+          OUTPUTS=$(az deployment sub show --name "$NAME" --query properties.outputs -o json)
+          AGW_FQDN=$(echo "$OUTPUTS" | jq -r '.apiGatewayFqdn.value')
+          SCALAR_URL=$(echo "$OUTPUTS" | jq -r '.scalarUrl.value')
+          AGW_REDIRECT=$(echo "$OUTPUTS" | jq -r '.apiGatewayRedirectUri.value')
+          {
+            echo "apigateway_fqdn=${AGW_FQDN}"
+            echo "scalar_url=${SCALAR_URL}"
+            echo "apigateway_redirect=${AGW_REDIRECT}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Job summary
+        run: |
+          {
+            echo "## ppe deployed"
+            echo "- Image tag: \`${{ steps.tag.outputs.imageTag }}\`"
+            echo "- Scalar: ${{ steps.deploy.outputs.scalar_url }}"
+            echo "- BFF: https://${{ steps.deploy.outputs.apigateway_fqdn }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy-prod:
+    needs: [build-images, deploy-ppe]
+    if: |
+      always() && needs.deploy-ppe.result == 'success' &&
+      (github.event_name == 'push' || github.event.inputs.environment == 'prod')
+    runs-on: ubuntu-latest
+    environment: prod
+    concurrency:
+      group: prod
+      cancel-in-progress: false
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      scalar_url: ${{ steps.deploy.outputs.scalar_url }}
+      apigateway_fqdn: ${{ steps.deploy.outputs.apigateway_fqdn }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          TAG="${{ github.event.inputs.imageTag }}"
+          if [ -z "$TAG" ]; then
+            TAG="${{ needs.build-images.outputs.imageTag }}"
+          fi
+          if [ -z "$TAG" ]; then
+            TAG="sha-${GITHUB_SHA::7}"
+          fi
+          echo "imageTag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy infra (azure.bicep — prod)
+        id: deploy
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.imageTag }}
+        run: |
+          set -euo pipefail
+          NAME="ftgo-prod-$(date -u +%Y%m%d%H%M%S)"
+          az deployment sub create \
+            --location eastus \
+            --template-file infra/bicep/azure.bicep \
+            --parameters infra/bicep/azure.prod.bicepparam \
+            --parameters imageTag="${IMAGE_TAG}" \
+            --name "$NAME" \
+            --only-show-errors \
+            --output none
+          OUTPUTS=$(az deployment sub show --name "$NAME" --query properties.outputs -o json)
+          AGW_FQDN=$(echo "$OUTPUTS" | jq -r '.apiGatewayFqdn.value')
+          SCALAR_URL=$(echo "$OUTPUTS" | jq -r '.scalarUrl.value')
+          AGW_REDIRECT=$(echo "$OUTPUTS" | jq -r '.apiGatewayRedirectUri.value')
+          {
+            echo "apigateway_fqdn=${AGW_FQDN}"
+            echo "scalar_url=${SCALAR_URL}"
+            echo "apigateway_redirect=${AGW_REDIRECT}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Job summary
+        run: |
+          {
+            echo "## prod deployed"
+            echo "- Image tag: \`${{ steps.tag.outputs.imageTag }}\`"
+            echo "- Scalar: ${{ steps.deploy.outputs.scalar_url }}"
+            echo "- BFF: https://${{ steps.deploy.outputs.apigateway_fqdn }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,92 @@
+# syntax=docker/dockerfile:1.7
+# Multi-service .NET 10 ASP.NET Core Dockerfile.
+# One file, parameterized via PROJECT build-arg — same image recipe, different entry point per service.
+#
+# Build:
+#   docker build --build-arg PROJECT=Ftgo.ApiGateway -t ftgo-apigateway .
+#
+# Base images: distroless chiseled (~95 MB final image, runs as non-root uid 11654 by default).
+# Auth tokens / JWT validation are culture-invariant, so plain noble-chiseled (no ICU/tzdata) is sufficient.
+
+ARG PROJECT
+ARG TARGETARCH
+
+# ─── Stage 1: restore (cached unless csprojs or central package files change) ───
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-noble AS restore
+ARG PROJECT
+ARG TARGETARCH
+WORKDIR /src
+
+# Central props affect every restore — copy first.
+COPY Directory.Build.props Directory.Packages.props EntraAuthPatterns.slnx ./
+
+# Copy ALL service csprojs (small files; this layer is cached as long as none of them change).
+# Including all of them lets us share one restore layer across services that ProjectReference each other.
+COPY src/Ftgo.Auth/Ftgo.Auth.csproj                         src/Ftgo.Auth/
+COPY src/Ftgo.Auth.Client/Ftgo.Auth.Client.csproj           src/Ftgo.Auth.Client/
+COPY src/Ftgo.ApiGateway/Ftgo.ApiGateway.csproj             src/Ftgo.ApiGateway/
+COPY src/Ftgo.OrderService/Ftgo.OrderService.csproj         src/Ftgo.OrderService/
+COPY src/Ftgo.RestaurantService/Ftgo.RestaurantService.csproj src/Ftgo.RestaurantService/
+COPY src/Ftgo.KitchenService/Ftgo.KitchenService.csproj     src/Ftgo.KitchenService/
+COPY src/Ftgo.AccountingService/Ftgo.AccountingService.csproj src/Ftgo.AccountingService/
+COPY src/Ftgo.DeliveryService/Ftgo.DeliveryService.csproj   src/Ftgo.DeliveryService/
+COPY src/Ftgo.NotificationService/Ftgo.NotificationService.csproj src/Ftgo.NotificationService/
+COPY src/Ftgo.ApiGateway/packages.lock.json                 src/Ftgo.ApiGateway/
+COPY src/Ftgo.OrderService/packages.lock.json               src/Ftgo.OrderService/
+COPY src/Ftgo.RestaurantService/packages.lock.json          src/Ftgo.RestaurantService/
+COPY src/Ftgo.KitchenService/packages.lock.json             src/Ftgo.KitchenService/
+COPY src/Ftgo.AccountingService/packages.lock.json          src/Ftgo.AccountingService/
+COPY src/Ftgo.DeliveryService/packages.lock.json            src/Ftgo.DeliveryService/
+COPY src/Ftgo.NotificationService/packages.lock.json        src/Ftgo.NotificationService/
+COPY src/Ftgo.Auth/packages.lock.json                       src/Ftgo.Auth/
+COPY src/Ftgo.Auth.Client/packages.lock.json                src/Ftgo.Auth.Client/
+
+RUN --mount=type=cache,target=/root/.nuget/packages \
+    dotnet restore -a $TARGETARCH --locked-mode src/${PROJECT}/${PROJECT}.csproj
+
+# ─── Stage 2: publish ───
+FROM restore AS publish
+ARG PROJECT
+ARG TARGETARCH
+ARG BUILD_GIT_SHA=local
+ARG BUILD_VERSION=0.0.0-local
+COPY src/ src/
+RUN --mount=type=cache,target=/root/.nuget/packages \
+    dotnet publish src/${PROJECT}/${PROJECT}.csproj \
+        -a $TARGETARCH \
+        --no-restore \
+        -c Release \
+        -o /app \
+        -p:UseAppHost=false \
+        -p:DebugType=embedded \
+        -p:Version=$BUILD_VERSION \
+        -p:SourceRevisionId=$BUILD_GIT_SHA \
+    && for f in /app/${PROJECT}.*; do mv "$f" "${f/${PROJECT}/app}"; done
+
+# ─── Stage 3: runtime (chiseled, ~95 MB, runs as uid 11654 non-root by default) ───
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled AS runtime
+ARG PROJECT
+ARG BUILD_GIT_SHA=local
+ARG BUILD_VERSION=0.0.0-local
+ARG BUILD_TIMESTAMP=unknown
+
+# OCI labels — GHCR uses 'org.opencontainers.image.source' to auto-link the package to the repo.
+LABEL org.opencontainers.image.source="https://github.com/mghabin/entra-auth-patterns-dotnet" \
+      org.opencontainers.image.description="Entra Auth Patterns sample — service container" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.revision="${BUILD_GIT_SHA}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+
+WORKDIR /app
+COPY --from=publish /app .
+
+# ASP.NET Core defaults to port 8080 in container images since .NET 8.
+EXPOSE 8080
+ENV ASPNETCORE_HTTP_PORTS=8080 \
+    ASPNETCORE_ENVIRONMENT=Production \
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+# Publish stage renames ${PROJECT}.* → app.*, so the entrypoint is the same for every service.
+# Chiseled's appuser (uid 11654) is already the default USER.
+ENTRYPOINT ["dotnet", "app.dll"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # entra-auth-patterns-dotnet
 
 [![CI](https://github.com/mghabin/entra-auth-patterns-dotnet/actions/workflows/ci.yml/badge.svg)](https://github.com/mghabin/entra-auth-patterns-dotnet/actions/workflows/ci.yml)
+[![CD](https://github.com/mghabin/entra-auth-patterns-dotnet/actions/workflows/cd.yml/badge.svg)](https://github.com/mghabin/entra-auth-patterns-dotnet/actions/workflows/cd.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com)
 
@@ -38,6 +39,17 @@ dotnet test  EntraAuthPatterns.slnx
 ```
 
 Full free-tier walkthrough → [`docs/run-locally.md`](docs/run-locally.md).
+
+## Deploy to the cloud
+
+Free-tier Azure Container Apps deployment with **dev → ppe → prod** promotion via GitHub Actions OIDC, image promotion by SHA, App Insights observability, zero stored client secrets:
+
+```bash
+./scripts/bootstrap-env.sh ENV=dev   # one-time per env
+git push origin main                 # auto-deploys to dev → ppe → prod (with reviewer gate)
+```
+
+Costs **$0/mo at idle** (scale-to-zero) and ~$3-5/mo with prod always-on. Full guide → [`docs/deploy-cloud.md`](docs/deploy-cloud.md), promotion model → [`docs/environments.md`](docs/environments.md).
 
 ## Docs
 

--- a/docs/deploy-cloud.md
+++ b/docs/deploy-cloud.md
@@ -1,0 +1,125 @@
+# Cloud deployment
+
+Deploys all 7 FTGO services to **Azure Container Apps** in three environments — **dev → ppe → prod** — promoted by GitHub Actions OIDC. Zero stored client secrets, free-tier-friendly, ~$0/mo at idle.
+
+## Architecture
+
+```
+GitHub repo (push to main)
+  │
+  └─ .github/workflows/cd.yml
+       1. Build 7 images → ghcr.io/mghabin/ftgo-*:sha-XXX     (free, public)
+       2. Deploy dev   (OIDC, no secrets)        ─┐
+       3. Promote to ppe                          ├─ same image digest
+       4. Promote to prod (required reviewer)    ─┘
+
+Per-env Azure resources (resource group rg-ftgo-{env}-eastus):
+  ├─ Log Analytics workspace               (free tier: 5 GB/mo)
+  ├─ Application Insights                  (workspace-based)
+  ├─ Container Apps managed environment
+  │    ├─ 3 web apps  (apigateway, orderservice, restaurantservice)
+  │    │   scale 0–3, http-concurrency rule, /health probe
+  │    └─ 4 workers   (kitchen, accounting, delivery, notification)
+  │        scale 1–3, CPU rule, no ingress
+  └─ Key Vault                             (RBAC, secrets used by NotificationService)
+```
+
+Identity:
+- **CD identity:** one user-assigned MI per env (`ftgo-{env}-cd-mi`), federated to GitHub Actions via `repo:OWNER/REPO:environment:{env}`.
+- **Service identity:** each ACA app gets a system-assigned MI. Each MI is federated to its corresponding Entra app registration so the service uses `SignedAssertionFromManagedIdentity` for downstream calls — no certs, no secrets.
+
+## One-time bootstrap (per environment)
+
+Each environment needs its CD identity and GitHub Environment created **once** before the workflow can deploy. Run from a workstation logged in to Azure (Owner on the subscription) and `gh` (admin on the repo):
+
+```bash
+./scripts/bootstrap-env.sh ENV=dev
+./scripts/bootstrap-env.sh ENV=ppe
+./scripts/bootstrap-env.sh ENV=prod   # also configures required-reviewer rule
+```
+
+What this does (per env, idempotent):
+1. Creates `rg-ftgo-{env}-eastus`.
+2. Creates `ftgo-{env}-cd-mi` user-assigned MI in that RG.
+3. Creates a federated identity credential bound to `repo:OWNER/REPO:environment:{env}`.
+4. Grants Contributor on the resource group; for prod, also User Access Administrator (so it can grant Key Vault RBAC).
+5. Creates the GitHub Environment, sets `AZURE_CLIENT_ID` / `AZURE_SUBSCRIPTION_ID` env variables, and (one-time) the repo-scoped `AZURE_TENANT_ID` secret.
+6. For prod, requires a single reviewer before deploys can proceed.
+
+Re-running on an already-bootstrapped env is a no-op.
+
+## First deploy
+
+After bootstrapping `dev`:
+
+```bash
+git push origin main
+```
+
+The workflow auto-deploys to dev. Watch progress under **Actions → CD → deploy-dev**. The job summary prints the BFF FQDN and Scalar URL.
+
+## Provisioning per-env Entra app registrations
+
+The CD identity is intentionally scoped to ARM only (no Microsoft Graph). Entra app regs are provisioned **out-of-band**, once per env, after the first infra deploy:
+
+```bash
+./scripts/provision-apps.sh ENV=dev
+./scripts/provision-apps.sh ENV=ppe
+./scripts/provision-apps.sh ENV=prod
+```
+
+This:
+- Reads the most recent `azure.bicep` deployment outputs (BFF FQDN, ACA principal IDs).
+- Runs `main.bicep` for env-suffixed app regs (`ftgo-dev-apigateway`, ...).
+- Federates each ACA system MI to its corresponding app registration (so services can mint client assertions via MI).
+
+## Promoting to ppe and prod
+
+After the dev deploy succeeds, the same workflow run automatically continues to `deploy-ppe` (no gate) and then `deploy-prod` (waits for a reviewer). The **same image digest** is promoted — no rebuild.
+
+To promote a previously-built SHA on demand (e.g. roll back):
+
+```bash
+gh workflow run cd.yml -f environment=prod -f imageTag=sha-abc1234
+```
+
+## Verification
+
+Real teams verify production from telemetry, not curl-in-CI. Use:
+- **Per-env Scalar UI**: `https://ftgo-{env}-apigateway-eus.<cae-domain>.azurecontainerapps.io/scalar/v1`
+- **App Insights live metrics + dependency map** — full OBO/s2s call chain
+- **Failure alerts** — wire a free Action Group → email when 5xx exceeds threshold
+
+## Cost estimate
+
+| Scenario | dev | ppe | prod | Total /mo |
+|---|---|---|---|---|
+| All envs scale-to-zero (idle) | $0 | $0 | $0 | **$0** |
+| Prod 1 replica × 7 svcs always-on | $0 | $0 | ~$3-5 | **~$3-5** |
+| Sustained 10 req/s prod (scale 1-3) | $0 | $0 | ~$15-25 | ~$15-25 |
+
+Free-tier ceilings (per Azure subscription):
+- ACA Consumption: 180k vCPU-s + 360k GiB-s/mo
+- Log Analytics: 5 GB ingest/mo
+- App Insights: included with workspace-based LAW
+- Egress: 100 GB/mo
+- ghcr.io public images and GitHub Actions on a public repo: free, unlimited
+
+## File layout
+
+| Path | Purpose |
+|---|---|
+| `Dockerfile` | Single parameterized multi-service Dockerfile (chiseled, ~95 MB) |
+| `infra/bicep/azure.bicep` | Subscription-scope orchestrator (per-env Azure infra) |
+| `infra/bicep/azure.{env}.bicepparam` | Per-env parameters |
+| `infra/bicep/main.bicep` | Tenant-scope orchestrator (Entra app regs) |
+| `infra/bicep/main.{env}.bicepparam` | Per-env Entra app reg params |
+| `.github/workflows/cd.yml` | CD pipeline |
+| `.github/workflows/cd-cleanup.yml` | Nightly scale-reset for dev/ppe |
+| `scripts/bootstrap-env.sh` | One-time per-env bootstrap |
+| `scripts/provision-apps.sh` | Per-env Entra app provisioning |
+
+## See also
+
+- [`docs/environments.md`](environments.md) — promotion model, adding a 4th env
+- [`docs/run-locally.md`](run-locally.md) — local-dev path (not cloud)

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,71 @@
+# Environments
+
+Three environments share one Azure subscription and one Entra tenant:
+
+| Env | RG | Trigger | Gate |
+|---|---|---|---|
+| **dev** | `rg-ftgo-dev-eastus` | every push to `main` | dev success |
+| **ppe** | `rg-ftgo-ppe-eastus` | dev success | (none — auto-promote) |
+| **prod** | `rg-ftgo-prod-eastus` | ppe success | required reviewer |
+
+## Promotion model
+
+```
+push → build-images (matrix × 7) → tags :sha-XXX, :latest
+            │
+            ▼
+   deploy-dev  (always-on path)
+            │ (success)
+            ▼
+   deploy-ppe  (concurrency-group: ppe)
+            │ (success)
+            ▼
+   deploy-prod (concurrency-group: prod, env reviewer required)
+```
+
+- **Single image digest** is deployed to all three envs — built once, promoted many.
+- `workflow_dispatch` accepts an `imageTag` input to redeploy a previously-built SHA without rebuilding.
+- `cancel-in-progress: false` on ppe/prod so a follow-up push never interrupts a running deploy.
+
+## Per-env configuration
+
+What lives where:
+
+| Layer | Source | Per-env? |
+|---|---|---|
+| Image build (registry, tag) | `cd.yml` | no |
+| Azure infra | `infra/bicep/azure.bicep` + `azure.{env}.bicepparam` | yes |
+| Entra app regs | `infra/bicep/main.bicep` + `main.{env}.bicepparam` | yes |
+| ACA scale, ingress, env vars | `container-app.bicep` (driven by `aca-stack.bicep`) | shape only — values uniform |
+| Application Insights connection | injected by Bicep at deploy time | yes |
+| `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID` | GitHub Environment **variables** | yes |
+| `AZURE_TENANT_ID` | repo **secret** | no (single tenant) |
+
+The CD identity per env (`ftgo-{env}-cd-mi`) is scoped to its own resource group only — no cross-env access.
+
+## Adding a 4th environment (e.g., `staging`)
+
+1. Add `infra/bicep/azure.staging.bicepparam` and `infra/bicep/main.staging.bicepparam`.
+2. `./scripts/bootstrap-env.sh ENV=staging`.
+3. Add a `deploy-staging` job to `cd.yml`, modeled on `deploy-ppe`, with `needs:` set to the upstream env you want it promoted from.
+4. `./scripts/provision-apps.sh ENV=staging` after the first deploy.
+
+## Production guardrails
+
+- **Required reviewer** on the `prod` GitHub Environment (configured by `bootstrap-env.sh`).
+- **Concurrency group `prod`** with `cancel-in-progress: false`.
+- **No nightly scale-reset** for prod (the cleanup workflow skips it).
+- **Min replicas = 0** for prod web apps too. To pin one replica to eliminate cold-start, override `cpu`/`memory` and `minReplicas` via the bicepparam file (left as a knob; default is scale-to-zero everywhere for free-tier safety).
+
+## Cleanup
+
+Nightly at 03:00 UTC, `cd-cleanup.yml` resets every dev and ppe container app to `min=0/max=3`. This is a defensive measure against forgotten always-on overrides; it never touches prod.
+
+To tear down an env entirely:
+
+```bash
+az group delete --name rg-ftgo-dev-eastus --yes --no-wait
+gh api -X DELETE repos/OWNER/REPO/environments/dev
+```
+
+The federated credential and the user-assigned MI go away with the resource group.

--- a/infra/bicep/azure.bicep
+++ b/infra/bicep/azure.bicep
@@ -1,0 +1,145 @@
+metadata name = 'azure-orchestrator'
+metadata description = 'Subscription-scope orchestrator that creates rg-ftgo-{env}-{location} and deploys Log Analytics, App Insights, Key Vault, the Container Apps managed environment, the 7 FTGO container apps, and Key Vault RBAC for their managed identities.'
+
+extension az
+
+targetScope = 'subscription'
+
+@description('Logical environment name; controls resource-group, naming, and ASPNETCORE_ENVIRONMENT.')
+@allowed([ 'dev', 'ppe', 'prod' ])
+param environmentName string
+
+@description('Azure region for every resource. Defaults to eastus (largest free quota).')
+param location string = 'eastus'
+
+@description('Image tag applied uniformly across all 7 services (e.g. sha-abc1234, latest).')
+param imageTag string = 'latest'
+
+@description('Container registry base. Public images: anonymous pull, no registry credentials needed.')
+param containerRegistry string = 'ghcr.io/mghabin'
+
+@description('Tags applied to every resource.')
+param tags object = {
+  environment: environmentName
+  workload:    'ftgo'
+  managedBy:   'bicep'
+}
+
+// Region → short token folded into resource names. Falls back to first 3 chars for unmapped regions.
+var regionShortMap = {
+  eastus:       'eus'
+  eastus2:      'eus2'
+  westus2:      'wus2'
+  westeurope:   'weu'
+  northeurope:  'neu'
+  centralus:    'cus'
+}
+var regionShort = regionShortMap[?location] ?? toLower(take(location, 3))
+
+var rgName       = 'rg-ftgo-${environmentName}-${location}'
+var lawName      = 'ftgo-${environmentName}-law-${regionShort}'
+var aiName       = 'ftgo-${environmentName}-ai-${regionShort}'
+var caeName      = 'ftgo-${environmentName}-cae-${regionShort}'
+// KV global uniqueness: 'kv-ftgo-{env}-{8-char hash of rg.id}' = max 21 chars (within the 24 limit).
+var kvName       = 'kv-ftgo-${environmentName}-${take(uniqueString(subscription().subscriptionId, rgName), 8)}'
+
+resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name:     rgName
+  location: location
+  tags:     tags
+}
+
+module logAnalytics 'modules/log-analytics.bicep' = {
+  name:  'law'
+  scope: resourceGroup(rg.name)
+  params: {
+    name:     lawName
+    location: location
+    tags:     tags
+  }
+}
+
+module appInsights 'modules/app-insights.bicep' = {
+  name:  'ai'
+  scope: resourceGroup(rg.name)
+  params: {
+    name:                aiName
+    location:            location
+    workspaceResourceId: logAnalytics.outputs.workspaceId
+    tags:                tags
+  }
+}
+
+module keyVault 'modules/key-vault.bicep' = {
+  name:  'kv'
+  scope: resourceGroup(rg.name)
+  params: {
+    name:     kvName
+    location: location
+    tenantId: subscription().tenantId
+    tags:     tags
+  }
+}
+
+module containerAppsEnv 'modules/container-apps-environment.bicep' = {
+  name:  'cae'
+  scope: resourceGroup(rg.name)
+  params: {
+    name:                    caeName
+    location:                location
+    logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
+    logAnalyticsCustomerId:  logAnalytics.outputs.customerId
+    tags:                    tags
+  }
+}
+
+module acaStack 'modules/aca-stack.bicep' = {
+  name:  'aca-stack'
+  scope: resourceGroup(rg.name)
+  params: {
+    environmentName:             environmentName
+    location:                    location
+    containerAppsEnvironmentId:  containerAppsEnv.outputs.environmentId
+    appInsightsConnectionString: appInsights.outputs.connectionString
+    containerRegistry:           containerRegistry
+    imageTag:                    imageTag
+    regionShort:                 regionShort
+    tags:                        tags
+  }
+}
+
+module kvRbac 'modules/key-vault-rbac.bicep' = {
+  name:  'kv-rbac'
+  scope: resourceGroup(rg.name)
+  params: {
+    keyVaultName: keyVault.outputs.keyVaultName
+    principalIds: acaStack.outputs.principalIds
+  }
+}
+
+@description('Resource group containing every FTGO resource for this environment.')
+output resourceGroupName string = rg.name
+
+@description('Log Analytics workspace resource ID.')
+output logAnalyticsWorkspaceId string = logAnalytics.outputs.workspaceId
+
+@description('App Insights component resource ID. Connection string is *not* output (kept inside the deployment).')
+output appInsightsId string = appInsights.outputs.id
+
+@description('Key Vault URI.')
+output keyVaultUri string = keyVault.outputs.vaultUri
+
+@description('Container Apps managed environment default domain.')
+output containerAppsDefaultDomain string = containerAppsEnv.outputs.defaultDomain
+
+@description('Map of shortName → { fqdn, principalId, name } for the 7 deployed services.')
+output services object = acaStack.outputs.services
+
+@description('FQDN of the API gateway (BFF) for redirect-uri wiring on the Entra apps.')
+output apiGatewayFqdn string = acaStack.outputs.services.apigateway.fqdn
+
+@description('Scalar API explorer URL on the BFF.')
+output scalarUrl string = 'https://${acaStack.outputs.services.apigateway.fqdn}/scalar/v1'
+
+@description('OIDC sign-in URL on the BFF (paste into Entra app reg redirect URIs).')
+output apiGatewayRedirectUri string = 'https://${acaStack.outputs.services.apigateway.fqdn}/signin-oidc'

--- a/infra/bicep/azure.dev.bicepparam
+++ b/infra/bicep/azure.dev.bicepparam
@@ -1,0 +1,13 @@
+// Cloud-dev provisioning of the FTGO Azure stack into rg-ftgo-dev-eastus.
+// Deploy:
+//   IMAGE_TAG=sha-abc1234 \
+//     az deployment sub create --location eastus \
+//       --template-file infra/bicep/azure.bicep \
+//       --parameters infra/bicep/azure.dev.bicepparam
+
+using 'azure.bicep'
+
+param environmentName   = 'dev'
+param location          = 'eastus'
+param imageTag          = readEnvironmentVariable('IMAGE_TAG',          'latest')
+param containerRegistry = readEnvironmentVariable('CONTAINER_REGISTRY', 'ghcr.io/mghabin')

--- a/infra/bicep/azure.ppe.bicepparam
+++ b/infra/bicep/azure.ppe.bicepparam
@@ -1,0 +1,13 @@
+// Cloud-PPE provisioning of the FTGO Azure stack into rg-ftgo-ppe-eastus.
+// Deploy:
+//   IMAGE_TAG=sha-abc1234 \
+//     az deployment sub create --location eastus \
+//       --template-file infra/bicep/azure.bicep \
+//       --parameters infra/bicep/azure.ppe.bicepparam
+
+using 'azure.bicep'
+
+param environmentName   = 'ppe'
+param location          = 'eastus'
+param imageTag          = readEnvironmentVariable('IMAGE_TAG',          'latest')
+param containerRegistry = readEnvironmentVariable('CONTAINER_REGISTRY', 'ghcr.io/mghabin')

--- a/infra/bicep/azure.prod.bicepparam
+++ b/infra/bicep/azure.prod.bicepparam
@@ -1,0 +1,13 @@
+// Cloud-prod provisioning of the FTGO Azure stack into rg-ftgo-prod-eastus.
+// Deploy:
+//   IMAGE_TAG=sha-abc1234 \
+//     az deployment sub create --location eastus \
+//       --template-file infra/bicep/azure.bicep \
+//       --parameters infra/bicep/azure.prod.bicepparam
+
+using 'azure.bicep'
+
+param environmentName   = 'prod'
+param location          = 'eastus'
+param imageTag          = readEnvironmentVariable('IMAGE_TAG',          'latest')
+param containerRegistry = readEnvironmentVariable('CONTAINER_REGISTRY', 'ghcr.io/mghabin')

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -16,17 +16,23 @@ param tenantId string
 @maxLength(16)
 param prefix string = 'ftgo'
 
+@description('Logical environment name. "local" keeps the existing local-dev names (ftgo-*); cloud envs (dev/ppe/prod) suffix it (ftgo-dev-*).')
+@allowed([ 'local', 'dev', 'ppe', 'prod' ])
+param environmentName string = 'local'
+
 @description('OIDC redirect URI registered on the BFF for local-dev sign-in.')
 param apiGatewayRedirectUri string = 'https://localhost:7101/signin-oidc'
 
 @description('SPA redirect URI for Scalar PKCE callback on the BFF.')
 param scalarRedirectUri string = 'https://localhost:7101/scalar/v1'
 
+var effectivePrefix = environmentName == 'local' ? prefix : '${prefix}-${environmentName}'
+
 module appRegistrations 'modules/app-registrations.bicep' = {
   name: 'app-registrations'
   params: {
     tenantId:              tenantId
-    prefix:                prefix
+    prefix:                effectivePrefix
     apiGatewayRedirectUri: apiGatewayRedirectUri
     scalarRedirectUri:     scalarRedirectUri
   }
@@ -40,7 +46,8 @@ module permissionGrants 'modules/permission-grants.bicep' = {
   }
 }
 
-output tenantId string = tenantId
-output apps     object = appRegistrations.outputs.apps
-output roleIds  object = appRegistrations.outputs.roleIds
+output tenantId        string = tenantId
+output environmentName string = environmentName
+output apps            object = appRegistrations.outputs.apps
+output roleIds         object = appRegistrations.outputs.roleIds
 

--- a/infra/bicep/main.dev.bicepparam
+++ b/infra/bicep/main.dev.bicepparam
@@ -1,0 +1,21 @@
+// Entra app-reg provisioning for the cloud-DEV environment (suffixes display names with -dev).
+//
+// The redirect URIs need to point at the BFF's ACA FQDN, which we don't know
+// until azure.bicep has finished deploying (the FQDN folds in cae.defaultDomain,
+// a per-environment random token). The bicepparam therefore reads the URIs
+// from env vars set by scripts/deploy.sh after the azure-stack deployment:
+//
+//   FTGO_GATEWAY_REDIRECT_URI=https://<bff-fqdn>/signin-oidc
+//   FTGO_SCALAR_REDIRECT_URI=https://<bff-fqdn>/scalar/v1
+//
+// The placeholder defaults are based on the *expected* app name and assume
+// eastus; they let `bicep build-params` succeed without env vars set, but
+// you must override them before the actual tenant deployment.
+
+using 'main.bicep'
+
+param tenantId             = readEnvironmentVariable('AZURE_TENANT_ID')
+param prefix               = readEnvironmentVariable('FTGO_PREFIX',                'ftgo')
+param environmentName      = 'dev'
+param apiGatewayRedirectUri = readEnvironmentVariable('FTGO_GATEWAY_REDIRECT_URI', 'https://ftgo-dev-apigateway-eus.eastus.azurecontainerapps.io/signin-oidc')
+param scalarRedirectUri     = readEnvironmentVariable('FTGO_SCALAR_REDIRECT_URI',  'https://ftgo-dev-apigateway-eus.eastus.azurecontainerapps.io/scalar/v1')

--- a/infra/bicep/main.ppe.bicepparam
+++ b/infra/bicep/main.ppe.bicepparam
@@ -1,0 +1,10 @@
+// Entra app-reg provisioning for the cloud-PPE environment (suffixes display names with -ppe).
+// See main.dev.bicepparam for the rationale on FTGO_GATEWAY_REDIRECT_URI / FTGO_SCALAR_REDIRECT_URI.
+
+using 'main.bicep'
+
+param tenantId             = readEnvironmentVariable('AZURE_TENANT_ID')
+param prefix               = readEnvironmentVariable('FTGO_PREFIX',                'ftgo')
+param environmentName      = 'ppe'
+param apiGatewayRedirectUri = readEnvironmentVariable('FTGO_GATEWAY_REDIRECT_URI', 'https://ftgo-ppe-apigateway-eus.eastus.azurecontainerapps.io/signin-oidc')
+param scalarRedirectUri     = readEnvironmentVariable('FTGO_SCALAR_REDIRECT_URI',  'https://ftgo-ppe-apigateway-eus.eastus.azurecontainerapps.io/scalar/v1')

--- a/infra/bicep/main.prod.bicepparam
+++ b/infra/bicep/main.prod.bicepparam
@@ -1,0 +1,10 @@
+// Entra app-reg provisioning for the cloud-PROD environment (suffixes display names with -prod).
+// See main.dev.bicepparam for the rationale on FTGO_GATEWAY_REDIRECT_URI / FTGO_SCALAR_REDIRECT_URI.
+
+using 'main.bicep'
+
+param tenantId             = readEnvironmentVariable('AZURE_TENANT_ID')
+param prefix               = readEnvironmentVariable('FTGO_PREFIX',                'ftgo')
+param environmentName      = 'prod'
+param apiGatewayRedirectUri = readEnvironmentVariable('FTGO_GATEWAY_REDIRECT_URI', 'https://ftgo-prod-apigateway-eus.eastus.azurecontainerapps.io/signin-oidc')
+param scalarRedirectUri     = readEnvironmentVariable('FTGO_SCALAR_REDIRECT_URI',  'https://ftgo-prod-apigateway-eus.eastus.azurecontainerapps.io/scalar/v1')

--- a/infra/bicep/modules/aca-stack.bicep
+++ b/infra/bicep/modules/aca-stack.bicep
@@ -1,0 +1,69 @@
+metadata name = 'aca-stack'
+metadata description = 'Iterates over the FTGO service list and instantiates one container-app per service. Returns a shortName-keyed map of fqdn/principalId/name for downstream RBAC and outputs.'
+
+@description('Logical environment name (dev/ppe/prod).')
+param environmentName string
+
+@description('Azure region for the apps.')
+param location string
+
+@description('Resource ID of the Container Apps managed environment hosting all 7 apps.')
+param containerAppsEnvironmentId string
+
+@description('Application Insights connection string injected into every app.')
+param appInsightsConnectionString string
+
+@description('Container registry base (e.g. ghcr.io/mghabin). Final image: <registry>/ftgo-<shortName>:<imageTag>.')
+param containerRegistry string
+
+@description('Image tag applied uniformly across all 7 services (e.g. sha-abc1234, latest).')
+param imageTag string
+
+@description('Region-short token folded into the app name (e.g. eus for eastus).')
+param regionShort string
+
+@description('Tags applied to every container app.')
+param tags object = {}
+
+@description('Service definitions: project = csproj folder name, shortName = lowercase image/name suffix.')
+param services array = [
+  { project: 'Ftgo.ApiGateway',           shortName: 'apigateway'          }
+  { project: 'Ftgo.OrderService',         shortName: 'orderservice'        }
+  { project: 'Ftgo.RestaurantService',    shortName: 'restaurantservice'   }
+  { project: 'Ftgo.KitchenService',       shortName: 'kitchenservice'      }
+  { project: 'Ftgo.AccountingService',    shortName: 'accountingservice'   }
+  { project: 'Ftgo.DeliveryService',      shortName: 'deliveryservice'     }
+  { project: 'Ftgo.NotificationService',  shortName: 'notificationservice' }
+]
+
+module containerApps 'container-app.bicep' = [for svc in services: {
+  name: 'aca-${svc.shortName}'
+  params: {
+    appName:                     'ftgo-${environmentName}-${svc.shortName}-${regionShort}'
+    serviceNameLower:            svc.shortName
+    location:                    location
+    containerAppsEnvironmentId:  containerAppsEnvironmentId
+    image:                       '${containerRegistry}/ftgo-${svc.shortName}:${imageTag}'
+    appInsightsConnectionString: appInsightsConnectionString
+    environmentName:             environmentName
+    tags:                        tags
+  }
+}]
+
+// Map output is hard-coded to the canonical 7-service ordering of the `services`
+// param default. If callers override `services`, they must keep the same ordering
+// (apigateway, orderservice, restaurantservice, kitchenservice, accountingservice,
+// deliveryservice, notificationservice) or rebuild the map themselves.
+@description('Map of shortName → { fqdn, principalId, name } for the deployed apps.')
+output services object = {
+  apigateway:          { fqdn: containerApps[0].outputs.fqdn, principalId: containerApps[0].outputs.principalId, name: containerApps[0].outputs.name }
+  orderservice:        { fqdn: containerApps[1].outputs.fqdn, principalId: containerApps[1].outputs.principalId, name: containerApps[1].outputs.name }
+  restaurantservice:   { fqdn: containerApps[2].outputs.fqdn, principalId: containerApps[2].outputs.principalId, name: containerApps[2].outputs.name }
+  kitchenservice:      { fqdn: containerApps[3].outputs.fqdn, principalId: containerApps[3].outputs.principalId, name: containerApps[3].outputs.name }
+  accountingservice:   { fqdn: containerApps[4].outputs.fqdn, principalId: containerApps[4].outputs.principalId, name: containerApps[4].outputs.name }
+  deliveryservice:     { fqdn: containerApps[5].outputs.fqdn, principalId: containerApps[5].outputs.principalId, name: containerApps[5].outputs.name }
+  notificationservice: { fqdn: containerApps[6].outputs.fqdn, principalId: containerApps[6].outputs.principalId, name: containerApps[6].outputs.name }
+}
+
+@description('Flat list of system-assigned principalIds for downstream RBAC (Key Vault, etc.).')
+output principalIds array = [for (svc, i) in services: containerApps[i].outputs.principalId]

--- a/infra/bicep/modules/aca-stack.bicep
+++ b/infra/bicep/modules/aca-stack.bicep
@@ -25,15 +25,15 @@ param regionShort string
 @description('Tags applied to every container app.')
 param tags object = {}
 
-@description('Service definitions: project = csproj folder name, shortName = lowercase image/name suffix.')
+@description('Service definitions: project = csproj folder name, shortName = lowercase image/name suffix, isWebApp = whether to expose HTTP ingress + /health probe.')
 param services array = [
-  { project: 'Ftgo.ApiGateway',           shortName: 'apigateway'          }
-  { project: 'Ftgo.OrderService',         shortName: 'orderservice'        }
-  { project: 'Ftgo.RestaurantService',    shortName: 'restaurantservice'   }
-  { project: 'Ftgo.KitchenService',       shortName: 'kitchenservice'      }
-  { project: 'Ftgo.AccountingService',    shortName: 'accountingservice'   }
-  { project: 'Ftgo.DeliveryService',      shortName: 'deliveryservice'     }
-  { project: 'Ftgo.NotificationService',  shortName: 'notificationservice' }
+  { project: 'Ftgo.ApiGateway',           shortName: 'apigateway',          isWebApp: true  }
+  { project: 'Ftgo.OrderService',         shortName: 'orderservice',        isWebApp: true  }
+  { project: 'Ftgo.RestaurantService',    shortName: 'restaurantservice',   isWebApp: true  }
+  { project: 'Ftgo.KitchenService',       shortName: 'kitchenservice',      isWebApp: false }
+  { project: 'Ftgo.AccountingService',    shortName: 'accountingservice',   isWebApp: false }
+  { project: 'Ftgo.DeliveryService',      shortName: 'deliveryservice',     isWebApp: false }
+  { project: 'Ftgo.NotificationService',  shortName: 'notificationservice', isWebApp: false }
 ]
 
 module containerApps 'container-app.bicep' = [for svc in services: {
@@ -46,6 +46,7 @@ module containerApps 'container-app.bicep' = [for svc in services: {
     image:                       '${containerRegistry}/ftgo-${svc.shortName}:${imageTag}'
     appInsightsConnectionString: appInsightsConnectionString
     environmentName:             environmentName
+    enableIngress:               svc.isWebApp
     tags:                        tags
   }
 }]

--- a/infra/bicep/modules/app-insights.bicep
+++ b/infra/bicep/modules/app-insights.bicep
@@ -1,0 +1,39 @@
+metadata name = 'app-insights'
+metadata description = 'Workspace-based Application Insights component pointing at the FTGO Log Analytics workspace.'
+
+extension az
+
+@description('Application Insights component name.')
+param name string
+
+@description('Azure region for the AI component.')
+param location string
+
+@description('Resource ID of the Log Analytics workspace backing this AI component.')
+param workspaceResourceId string
+
+@description('Tags applied to the AI component.')
+param tags object = {}
+
+resource ai 'Microsoft.Insights/components@2020-02-02' = {
+  name:     name
+  location: location
+  tags:     tags
+  kind:     'web'
+  properties: {
+    Application_Type:    'web'
+    WorkspaceResourceId: workspaceResourceId
+    IngestionMode:       'LogAnalytics'
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery:     'Enabled'
+  }
+}
+
+@description('Connection string injected into each container app as APPLICATIONINSIGHTS_CONNECTION_STRING.')
+output connectionString string = ai.properties.ConnectionString
+
+@description('Legacy instrumentation key (kept for compatibility; prefer the connection string).')
+output instrumentationKey string = ai.properties.InstrumentationKey
+
+@description('Resource ID of the AI component.')
+output id string = ai.id

--- a/infra/bicep/modules/app-registrations.bicep
+++ b/infra/bicep/modules/app-registrations.bicep
@@ -11,9 +11,9 @@ targetScope = 'tenant'
 @maxLength(36)
 param tenantId string
 
-@description('Prefix applied to every app registration display name (e.g. "ftgo" → "ftgo-orderservice").')
+@description('Prefix applied to every app registration display name (e.g. "ftgo" → "ftgo-orderservice"). When called from the cloud envs the orchestrator passes "ftgo-{env}".')
 @minLength(2)
-@maxLength(16)
+@maxLength(24)
 param prefix string
 
 @description('OIDC redirect URI registered on the BFF (api gateway) for local-dev sign-in.')

--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -33,6 +33,9 @@ param cpu string = '0.5'
 @description('Memory per replica.')
 param memory string = '1.0Gi'
 
+@description('When false, the app has no public ingress, no HTTP probe, and uses CPU-based scaling. Used for headless worker services.')
+param enableIngress bool = true
+
 var aspNetCoreEnvironment = '${toUpper(substring(environmentName, 0, 1))}${substring(environmentName, 1)}'
 
 resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
@@ -44,12 +47,14 @@ resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
   }
   properties: {
     environmentId: containerAppsEnvironmentId
-    configuration: {
+    configuration: union({
       activeRevisionsMode: 'Single'
+      registries: []
+    }, enableIngress ? {
       ingress: {
-        external:    true
-        targetPort:  8080
-        transport:   'auto'
+        external:      true
+        targetPort:    8080
+        transport:     'auto'
         allowInsecure: false
         traffic: [
           {
@@ -58,8 +63,7 @@ resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
           }
         ]
       }
-      registries: []
-    }
+    } : {})
     template: {
       containers: [
         {
@@ -83,7 +87,7 @@ resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
               value: appInsightsConnectionString
             }
           ]
-          probes: [
+          probes: enableIngress ? [
             {
               type: 'Liveness'
               httpGet: {
@@ -96,18 +100,29 @@ resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
               timeoutSeconds:      5
               failureThreshold:    3
             }
-          ]
+          ] : []
         }
       ]
       scale: {
-        minReplicas: 0
+        minReplicas: enableIngress ? 0 : 1
         maxReplicas: 3
-        rules: [
+        rules: enableIngress ? [
           {
             name: 'http-concurrency'
             http: {
               metadata: {
                 concurrentRequests: '5'
+              }
+            }
+          }
+        ] : [
+          {
+            name: 'cpu-load'
+            custom: {
+              type: 'cpu'
+              metadata: {
+                type:  'Utilization'
+                value: '70'
               }
             }
           }
@@ -117,8 +132,8 @@ resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
   }
 }
 
-@description('FQDN ACA assigned to the app (e.g. ftgo-dev-apigateway-eus.<random>.eastus.azurecontainerapps.io).')
-output fqdn string = app.properties.configuration.ingress.fqdn
+@description('FQDN ACA assigned to the app, or empty string for headless workers.')
+output fqdn string = enableIngress ? app.properties.configuration.ingress.fqdn : ''
 
 @description('System-assigned managed identity principalId — consumed by Key Vault RBAC.')
 output principalId string = app.identity.principalId

--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -1,0 +1,127 @@
+metadata name = 'container-app'
+metadata description = 'Single Azure Container App (Consumption) with system-assigned MI, external HTTP ingress on 8080, /health liveness probe, and 0–3 HTTP-concurrency scaling.'
+
+extension az
+
+@description('Container App resource name (e.g. ftgo-dev-apigateway-eus).')
+param appName string
+
+@description('Lowercased short service name (e.g. apigateway, orderservice). Used as the container name and image suffix.')
+param serviceNameLower string
+
+@description('Azure region for the app.')
+param location string
+
+@description('Resource ID of the Container Apps managed environment.')
+param containerAppsEnvironmentId string
+
+@description('Fully-qualified container image (e.g. ghcr.io/mghabin/ftgo-apigateway:sha-abc1234).')
+param image string
+
+@description('Application Insights connection string injected as APPLICATIONINSIGHTS_CONNECTION_STRING.')
+param appInsightsConnectionString string
+
+@description('Logical environment name (dev/ppe/prod). Capitalized into ASPNETCORE_ENVIRONMENT.')
+param environmentName string
+
+@description('Tags applied to the container app.')
+param tags object = {}
+
+@description('CPU cores per replica.')
+param cpu string = '0.5'
+
+@description('Memory per replica.')
+param memory string = '1.0Gi'
+
+var aspNetCoreEnvironment = '${toUpper(substring(environmentName, 0, 1))}${substring(environmentName, 1)}'
+
+resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
+  name:     appName
+  location: location
+  tags:     tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    environmentId: containerAppsEnvironmentId
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external:    true
+        targetPort:  8080
+        transport:   'auto'
+        allowInsecure: false
+        traffic: [
+          {
+            latestRevision: true
+            weight:         100
+          }
+        ]
+      }
+      registries: []
+    }
+    template: {
+      containers: [
+        {
+          name:  serviceNameLower
+          image: image
+          resources: {
+            cpu:    json(cpu)
+            memory: memory
+          }
+          env: [
+            {
+              name:  'ASPNETCORE_ENVIRONMENT'
+              value: aspNetCoreEnvironment
+            }
+            {
+              name:  'ASPNETCORE_HTTP_PORTS'
+              value: '8080'
+            }
+            {
+              name:  'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              value: appInsightsConnectionString
+            }
+          ]
+          probes: [
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/health'
+                port: 8080
+                scheme: 'HTTP'
+              }
+              initialDelaySeconds: 10
+              periodSeconds:       30
+              timeoutSeconds:      5
+              failureThreshold:    3
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 3
+        rules: [
+          {
+            name: 'http-concurrency'
+            http: {
+              metadata: {
+                concurrentRequests: '5'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+@description('FQDN ACA assigned to the app (e.g. ftgo-dev-apigateway-eus.<random>.eastus.azurecontainerapps.io).')
+output fqdn string = app.properties.configuration.ingress.fqdn
+
+@description('System-assigned managed identity principalId — consumed by Key Vault RBAC.')
+output principalId string = app.identity.principalId
+
+@description('Container app resource name.')
+output name string = app.name

--- a/infra/bicep/modules/container-apps-environment.bicep
+++ b/infra/bicep/modules/container-apps-environment.bicep
@@ -1,0 +1,48 @@
+metadata name = 'container-apps-environment'
+metadata description = 'Container Apps managed environment (Consumption) wired to the FTGO Log Analytics workspace.'
+
+extension az
+
+@description('Managed environment name.')
+param name string
+
+@description('Azure region for the environment.')
+param location string
+
+@description('Resource ID of the Log Analytics workspace receiving container app logs.')
+param logAnalyticsWorkspaceId string
+
+@description('Customer ID (workspace GUID) of the Log Analytics workspace.')
+param logAnalyticsCustomerId string
+
+@description('Tags applied to the environment.')
+param tags object = {}
+
+resource law 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+  name: last(split(logAnalyticsWorkspaceId, '/'))
+}
+
+resource cae 'Microsoft.App/managedEnvironments@2024-10-02-preview' = {
+  name:     name
+  location: location
+  tags:     tags
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalyticsCustomerId
+        sharedKey:  law.listKeys().primarySharedKey
+      }
+    }
+    zoneRedundant: false
+  }
+}
+
+@description('Resource ID of the managed environment (consumed by container-app modules).')
+output environmentId string = cae.id
+
+@description('Default domain ACA assigns to apps in this environment (e.g. <random>.eastus.azurecontainerapps.io).')
+output defaultDomain string = cae.properties.defaultDomain
+
+@description('Static IP for the environment (useful for diagnostics).')
+output staticIp string = cae.properties.staticIp

--- a/infra/bicep/modules/key-vault-rbac.bicep
+++ b/infra/bicep/modules/key-vault-rbac.bicep
@@ -1,0 +1,27 @@
+metadata name = 'key-vault-rbac'
+metadata description = 'Grants the "Key Vault Secrets User" role to a list of principalIds at the Key Vault scope. Deterministic role-assignment names so re-runs are idempotent.'
+
+extension az
+
+@description('Name of the existing Key Vault to scope role assignments to.')
+param keyVaultName string
+
+@description('List of system-assigned managed identity principalIds to grant the role to.')
+param principalIds array
+
+// Built-in role: Key Vault Secrets User
+var keyVaultSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
+
+resource kv 'Microsoft.KeyVault/vaults@2024-04-01-preview' existing = {
+  name: keyVaultName
+}
+
+resource secretsUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
+  name:  guid(kv.id, principalId, keyVaultSecretsUserRoleId)
+  scope: kv
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId:      principalId
+    principalType:    'ServicePrincipal'
+  }
+}]

--- a/infra/bicep/modules/key-vault.bicep
+++ b/infra/bicep/modules/key-vault.bicep
@@ -1,0 +1,49 @@
+metadata name = 'key-vault'
+metadata description = 'Standard-SKU Key Vault with RBAC authorization, soft-delete on, 7-day retention. Public network access enabled for ACA reachability.'
+
+extension az
+
+@description('Key Vault name (3–24 chars, globally unique). Caller is responsible for the length cap.')
+@minLength(3)
+@maxLength(24)
+param name string
+
+@description('Azure region for the vault.')
+param location string
+
+@description('Tenant id that owns the vault (used to scope RBAC role assignments).')
+param tenantId string
+
+@description('Tags applied to the vault.')
+param tags object = {}
+
+resource kv 'Microsoft.KeyVault/vaults@2024-04-01-preview' = {
+  name:     name
+  location: location
+  tags:     tags
+  properties: {
+    tenantId: tenantId
+    sku: {
+      family: 'A'
+      name:   'standard'
+    }
+    enableRbacAuthorization:   true
+    enableSoftDelete:          true
+    softDeleteRetentionInDays: 7
+    enablePurgeProtection:     null
+    publicNetworkAccess:       'Enabled'
+    networkAcls: {
+      defaultAction: 'Allow'
+      bypass:        'AzureServices'
+    }
+  }
+}
+
+@description('Vault URI (https://<name>.vault.azure.net/).')
+output vaultUri string = kv.properties.vaultUri
+
+@description('Vault name passed through for RBAC scoping.')
+output keyVaultName string = kv.name
+
+@description('Vault resource ID (used for role assignment scoping).')
+output id string = kv.id

--- a/infra/bicep/modules/log-analytics.bicep
+++ b/infra/bicep/modules/log-analytics.bicep
@@ -1,0 +1,42 @@
+metadata name = 'log-analytics'
+metadata description = 'Single Log Analytics workspace (PerGB2018) with a 1 GB/day cap to stay safely inside the free grant.'
+
+extension az
+
+@description('Workspace name (≤ 63 chars, lowercase, dash-separated).')
+param name string
+
+@description('Azure region for the workspace.')
+param location string
+
+@description('Tags applied to the workspace.')
+param tags object = {}
+
+resource law 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name:     name
+  location: location
+  tags:     tags
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays:   30
+    workspaceCapping: {
+      dailyQuotaGb: 1
+    }
+    features: {
+      enableLogAccessUsingOnlyResourcePermissions: true
+    }
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery:     'Enabled'
+  }
+}
+
+@description('Resource ID of the workspace (used by App Insights and Container Apps Environment).')
+output workspaceId string = law.id
+
+@description('Customer ID (workspace GUID) consumed by the Container Apps Environment log config.')
+output customerId string = law.properties.customerId
+
+@description('Workspace name passed through for downstream tagging/diagnostics.')
+output name string = law.name

--- a/scripts/bootstrap-env.sh
+++ b/scripts/bootstrap-env.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# scripts/bootstrap-env.sh — one-time per-environment bootstrap for the cloud CD pipeline.
+#
+# Provisions the bits the GitHub Actions cd.yml workflow assumes already exist:
+#   1. Resource group        rg-ftgo-${ENV}-eastus
+#   2. User-assigned MI      ftgo-${ENV}-cd-mi   (with GH OIDC federation)
+#   3. RBAC                  Contributor on the RG (+ User Access Admin for prod)
+#   4. GitHub Environment    ${ENV} (with required reviewer for prod)
+#   5. GH env vars           AZURE_CLIENT_ID, AZURE_SUBSCRIPTION_ID
+#   6. Repo secret           AZURE_TENANT_ID (one-time, shared across envs)
+#
+# Idempotent: re-running on a bootstrapped env is a no-op.
+#
+# Usage:
+#   ./scripts/bootstrap-env.sh ENV=dev
+#   ./scripts/bootstrap-env.sh ENV=prod
+#
+# Prereqs: bash 4+, az CLI logged in to the target subscription, gh CLI authenticated to the repo, jq.
+
+set -euo pipefail
+
+if (( BASH_VERSINFO[0] < 4 )); then
+  echo "ERROR: bash 4+ required (you have ${BASH_VERSION})." >&2
+  echo "       macOS: 'brew install bash' then re-run with /usr/local/bin/bash." >&2
+  exit 1
+fi
+
+ENV=""
+for arg in "$@"; do
+  case "$arg" in
+    ENV=*) ENV="${arg#ENV=}" ;;
+    -h|--help) sed -n '2,18p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "unknown arg: $arg (expected ENV=dev|ppe|prod)" >&2; exit 2 ;;
+  esac
+done
+
+case "$ENV" in
+  dev|ppe|prod) ;;
+  *) echo "ERROR: ENV must be one of dev|ppe|prod (got '${ENV}')." >&2; exit 2 ;;
+esac
+
+for tool in az gh jq; do
+  command -v "$tool" >/dev/null || { echo "ERROR: '$tool' not on PATH" >&2; exit 1; }
+done
+
+GH_OWNER="${GH_OWNER:-$(gh repo view --json owner --jq .owner.login)}"
+GH_REPO="${GH_REPO:-$(gh repo view --json name --jq .name)}"
+SUB_ID="$(az account show --query id -o tsv)"
+TENANT_ID="$(az account show --query tenantId -o tsv)"
+LOCATION="${LOCATION:-eastus}"
+RG_NAME="rg-ftgo-${ENV}-${LOCATION}"
+MI_NAME="ftgo-${ENV}-cd-mi"
+FIC_NAME="github-${ENV}"
+FIC_SUBJECT="repo:${GH_OWNER}/${GH_REPO}:environment:${ENV}"
+
+echo "==> repo         : ${GH_OWNER}/${GH_REPO}"
+echo "==> subscription : ${SUB_ID}"
+echo "==> tenant       : ${TENANT_ID}"
+echo "==> env          : ${ENV}  (rg=${RG_NAME}, mi=${MI_NAME})"
+echo
+
+# 1. Resource group
+echo "==> Resource group"
+if az group show --name "$RG_NAME" --only-show-errors --output none 2>/dev/null; then
+  echo "    $RG_NAME already exists"
+else
+  az group create --name "$RG_NAME" --location "$LOCATION" --only-show-errors --output none
+  echo "    created $RG_NAME"
+fi
+
+# 2. User-assigned managed identity
+echo "==> User-assigned managed identity"
+if az identity show --name "$MI_NAME" --resource-group "$RG_NAME" --only-show-errors --output none 2>/dev/null; then
+  echo "    $MI_NAME already exists"
+else
+  az identity create --name "$MI_NAME" --resource-group "$RG_NAME" --location "$LOCATION" --only-show-errors --output none
+  echo "    created $MI_NAME"
+fi
+MI_JSON=$(az identity show --name "$MI_NAME" --resource-group "$RG_NAME" -o json --only-show-errors)
+MI_CLIENT_ID=$(jq -r .clientId <<<"$MI_JSON")
+MI_PRINCIPAL_ID=$(jq -r .principalId <<<"$MI_JSON")
+echo "    clientId    = $MI_CLIENT_ID"
+echo "    principalId = $MI_PRINCIPAL_ID"
+
+# 3. Federated identity credential (GH Actions → MI)
+echo "==> Federated identity credential ($FIC_NAME)"
+if az identity federated-credential show \
+      --name "$FIC_NAME" --identity-name "$MI_NAME" --resource-group "$RG_NAME" \
+      --only-show-errors --output none 2>/dev/null; then
+  echo "    $FIC_NAME already exists"
+else
+  az identity federated-credential create \
+    --name "$FIC_NAME" \
+    --identity-name "$MI_NAME" \
+    --resource-group "$RG_NAME" \
+    --issuer "https://token.actions.githubusercontent.com" \
+    --subject "$FIC_SUBJECT" \
+    --audiences "api://AzureADTokenExchange" \
+    --only-show-errors --output none
+  echo "    created (subject=$FIC_SUBJECT)"
+fi
+
+# 4. RBAC
+assign_role() {
+  local role="$1" scope="$2"
+  if az role assignment list --assignee "$MI_PRINCIPAL_ID" --role "$role" --scope "$scope" \
+        --only-show-errors -o tsv --query '[].id' 2>/dev/null | grep -q .; then
+    echo "    '$role' already assigned at $scope"
+  else
+    az role assignment create --assignee-object-id "$MI_PRINCIPAL_ID" \
+      --assignee-principal-type ServicePrincipal \
+      --role "$role" --scope "$scope" --only-show-errors --output none
+    echo "    granted '$role' at $scope"
+  fi
+}
+RG_SCOPE="/subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}"
+echo "==> Role assignments"
+assign_role "Contributor" "$RG_SCOPE"
+if [[ "$ENV" == "prod" ]]; then
+  assign_role "User Access Administrator" "$RG_SCOPE"
+fi
+
+# 5. GitHub Environment + variables + reviewer (prod only)
+echo "==> GitHub Environment '$ENV'"
+if [[ "$ENV" == "prod" ]]; then
+  REVIEWER_ID=$(gh api "users/${GH_OWNER}" --jq .id)
+  ENV_BODY=$(jq -nc --argjson rid "$REVIEWER_ID" \
+    '{wait_timer: 0, prevent_self_review: false, reviewers: [{type: "User", id: $rid}], deployment_branch_policy: null}')
+else
+  ENV_BODY='{"wait_timer":0,"reviewers":[],"deployment_branch_policy":null}'
+fi
+echo "$ENV_BODY" | gh api -X PUT "repos/${GH_OWNER}/${GH_REPO}/environments/${ENV}" \
+  --input - --silent
+echo "    upserted environment '$ENV'"
+
+set_env_var() {
+  local name="$1" value="$2"
+  # Use gh variable set (supports --env). Idempotent: replaces existing value.
+  if gh variable set "$name" --env "$ENV" --body "$value" --repo "${GH_OWNER}/${GH_REPO}" >/dev/null 2>&1; then
+    echo "    var $name set"
+  else
+    # Fallback to REST in case the gh CLI version lacks --env support.
+    gh api -X PATCH "repos/${GH_OWNER}/${GH_REPO}/environments/${ENV}/variables/${name}" \
+      -f name="$name" -f value="$value" --silent 2>/dev/null \
+    || gh api -X POST "repos/${GH_OWNER}/${GH_REPO}/environments/${ENV}/variables" \
+      -f name="$name" -f value="$value" --silent
+    echo "    var $name set (via REST)"
+  fi
+}
+set_env_var "AZURE_CLIENT_ID"       "$MI_CLIENT_ID"
+set_env_var "AZURE_SUBSCRIPTION_ID" "$SUB_ID"
+
+# 6. Repo-level tenant secret (shared across envs; one-time)
+echo "==> Repo secret AZURE_TENANT_ID"
+if gh secret list --repo "${GH_OWNER}/${GH_REPO}" --json name --jq '.[].name' | grep -qx 'AZURE_TENANT_ID'; then
+  echo "    already set — leaving as-is"
+else
+  gh secret set AZURE_TENANT_ID --body "$TENANT_ID" --repo "${GH_OWNER}/${GH_REPO}" >/dev/null
+  echo "    set"
+fi
+
+cat <<EOF
+
+============================================================
+Environment ${ENV} bootstrapped:
+  - Resource group:     ${RG_NAME}
+  - GH OIDC identity:   ${MI_NAME} (clientId: ${MI_CLIENT_ID})
+  - GitHub Environment: https://github.com/${GH_OWNER}/${GH_REPO}/settings/environments
+  - Federated subject:  ${FIC_SUBJECT}
+
+Next:
+  - Push to main (auto-deploys dev → ppe → prod), or
+  - gh workflow run cd.yml -f environment=${ENV}
+============================================================
+EOF

--- a/scripts/provision-apps.sh
+++ b/scripts/provision-apps.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# scripts/provision-apps.sh — per-env Entra app provisioning for cloud envs (dev|ppe|prod).
+#
+# Sibling to scripts/deploy.sh (which handles the local-dev path). For cloud envs we deploy
+# infra/bicep/main.bicep at tenant scope to create the per-env app registrations, then create
+# federated identity credentials linking each non-BFF service's app reg to the system MI of its
+# Container App. Cloud services use SignedAssertionFromManagedIdentity (no client secrets, no certs).
+#
+# ORDERING: this script depends on infra/bicep/azure.bicep already being deployed for ${ENV}
+# (typically by the cd.yml workflow). It reads the most-recent sub-scope deployment outputs to
+# discover the BFF FQDN and each ACA app's principalId.
+#
+# Usage:
+#   ./scripts/provision-apps.sh ENV=dev
+#
+# Prereqs: bash 4+, az CLI logged in (Owner at root scope to write app regs), jq.
+
+set -euo pipefail
+
+if (( BASH_VERSINFO[0] < 4 )); then
+  echo "ERROR: bash 4+ required (you have ${BASH_VERSION})." >&2
+  exit 1
+fi
+
+ENV=""
+for arg in "$@"; do
+  case "$arg" in
+    ENV=*) ENV="${arg#ENV=}" ;;
+    -h|--help) sed -n '2,17p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "unknown arg: $arg (expected ENV=dev|ppe|prod)" >&2; exit 2 ;;
+  esac
+done
+
+case "$ENV" in
+  dev|ppe|prod) ;;
+  *) echo "ERROR: ENV must be one of dev|ppe|prod (got '${ENV}')." >&2; exit 2 ;;
+esac
+
+for tool in az jq; do
+  command -v "$tool" >/dev/null || { echo "ERROR: '$tool' not on PATH" >&2; exit 1; }
+done
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+RG_NAME="rg-ftgo-${ENV}-eastus"
+TENANT_ID="$(az account show --query tenantId -o tsv)"
+
+echo "==> tenant : $TENANT_ID"
+echo "==> env    : $ENV (rg=$RG_NAME)"
+
+# 1. Locate the most-recent successful azure.bicep deployment for this env.
+echo "==> Reading latest azure.bicep deployment outputs"
+LATEST_DEPLOY=$(az deployment sub list \
+  --query "[?starts_with(name, 'ftgo-${ENV}-') && properties.provisioningState=='Succeeded'] | sort_by(@, &properties.timestamp) | [-1].name" \
+  -o tsv --only-show-errors)
+if [[ -z "$LATEST_DEPLOY" ]]; then
+  echo "ERROR: no successful sub-scope deployment 'ftgo-${ENV}-*' found. Deploy azure.bicep first." >&2
+  exit 1
+fi
+echo "    deployment = $LATEST_DEPLOY"
+
+OUTPUTS=$(az deployment sub show --name "$LATEST_DEPLOY" --query properties.outputs -o json --only-show-errors)
+BFF_FQDN=$(jq -r '.apiGatewayFqdn.value' <<<"$OUTPUTS")
+SERVICES=$(jq -r '.services.value' <<<"$OUTPUTS")
+if [[ -z "$BFF_FQDN" || "$BFF_FQDN" == "null" ]]; then
+  echo "ERROR: deployment $LATEST_DEPLOY missing apiGatewayFqdn output." >&2
+  exit 1
+fi
+echo "    bff fqdn   = $BFF_FQDN"
+
+# 2. Tenant-scope deployment for the per-env app regs.
+echo "==> Deploying infra/bicep/main.bicep (env=$ENV)"
+DEPLOY_NAME="ftgo-entra-${ENV}-$(date -u +%Y%m%d%H%M%S)"
+AGW_REDIRECT="https://${BFF_FQDN}/signin-oidc"
+SCALAR_REDIRECT="https://${BFF_FQDN}/scalar/v1"
+
+az deployment tenant create \
+  --name "$DEPLOY_NAME" \
+  --location eastus \
+  --template-file "$ROOT/infra/bicep/main.bicep" \
+  --parameters "$ROOT/infra/bicep/main.${ENV}.bicepparam" \
+  --parameters apiGatewayRedirectUri="$AGW_REDIRECT" scalarRedirectUri="$SCALAR_REDIRECT" \
+  --only-show-errors --output none
+
+APPS=$(az deployment tenant show --name "$DEPLOY_NAME" --query 'properties.outputs.apps.value' -o json --only-show-errors)
+
+# 3. Federated identity credentials: each service's app reg ← its ACA system MI.
+#
+# SignedAssertionFromManagedIdentity flow: the service uses its system-assigned MI to mint a token
+# with audience `api://AzureADTokenExchange`. The app reg trusts that token via a federated credential
+# whose issuer is the tenant's STS, subject is the MI's clientId.
+#
+# Bicep keys:    apps[apiGateway|orderService|restaurantService|kitchenService|accountingService|deliveryService|notificationService]
+# Azure keys:    services[apigateway|orderservice|...]   (lowercased, no dot)
+declare -A SVC_TO_BICEP_KEY=(
+  [apigateway]=apiGateway
+  [orderservice]=orderService
+  [restaurantservice]=restaurantService
+  [kitchenservice]=kitchenService
+  [accountingservice]=accountingService
+  [deliveryservice]=deliveryService
+  [notificationservice]=notificationService
+)
+
+ISSUER="https://login.microsoftonline.com/${TENANT_ID}/v2.0"
+echo "==> Federated identity credentials"
+printf '    %-22s %-38s %s\n' SERVICE APP_ID FQDN
+
+for short in "${!SVC_TO_BICEP_KEY[@]}"; do
+  bicep_key="${SVC_TO_BICEP_KEY[$short]}"
+  app_id=$(jq -r --arg k "$bicep_key" '.[$k].appId // empty' <<<"$APPS")
+  # main.bicep outputs only {appId, spId}. The Graph object id isn't exposed, so
+  # resolve it on demand via the Graph appId → object lookup.
+  app_obj_id=""
+  if [[ -n "$app_id" ]]; then
+    app_obj_id=$(az ad app show --id "$app_id" --query id -o tsv --only-show-errors 2>/dev/null || echo "")
+  fi
+  fqdn=$(jq -r --arg k "$short" '.[$k].fqdn // empty' <<<"$SERVICES")
+  mi_client_id=$(az containerapp show --name "ftgo-${ENV}-${short}" --resource-group "$RG_NAME" \
+    --query 'identity.principalId' -o tsv --only-show-errors 2>/dev/null || true)
+  # The MI clientId is what we need as the FIC subject. principalId is the SP objectId — we need
+  # to look up the matching clientId.
+  mi_principal_id="$mi_client_id"
+  if [[ -n "$mi_principal_id" && "$mi_principal_id" != "None" ]]; then
+    mi_client_id=$(az ad sp show --id "$mi_principal_id" --query appId -o tsv --only-show-errors 2>/dev/null || echo "")
+  fi
+
+  printf '    %-22s %-38s %s\n' "$short" "${app_id:-?}" "${fqdn:-?}"
+
+  # Skip BFF — it doesn't use SignedAssertionFromManagedIdentity for downstream OBO directly via FIC
+  # on its own app reg in this pattern. (The BFF uses MI-issued client assertion against its own app
+  # reg too, so include it as well — keeps things uniform.)
+  if [[ -z "$app_id" || -z "$app_obj_id" || -z "$mi_client_id" ]]; then
+    echo "      skipped (missing appId / objectId / MI clientId)"
+    continue
+  fi
+
+  fic_name="aca-${ENV}-${short}"
+  if az ad app federated-credential list --id "$app_obj_id" \
+        --query "[?name=='${fic_name}']" -o tsv --only-show-errors 2>/dev/null | grep -q .; then
+    echo "      FIC '${fic_name}' already exists"
+  else
+    az ad app federated-credential create --id "$app_obj_id" --parameters "$(jq -nc \
+      --arg name "$fic_name" --arg issuer "$ISSUER" --arg sub "$mi_client_id" '{
+        name: $name,
+        issuer: $issuer,
+        subject: $sub,
+        description: "ACA system MI → app reg (SignedAssertionFromManagedIdentity)",
+        audiences: ["api://AzureADTokenExchange"]
+      }')" --only-show-errors --output none
+    echo "      created FIC '${fic_name}' (subject=${mi_client_id})"
+  fi
+done
+
+cat <<EOF
+
+============================================================
+Per-env Entra provisioning complete for ${ENV}.
+  - tenant deployment: $DEPLOY_NAME
+  - BFF redirect URI:  $AGW_REDIRECT
+  - Scalar redirect:   $SCALAR_REDIRECT
+============================================================
+EOF

--- a/src/Ftgo.AccountingService/packages.lock.json
+++ b/src/Ftgo.AccountingService/packages.lock.json
@@ -491,6 +491,19 @@
           "OpenTelemetry.Api": "1.15.3"
         }
       },
+      "OpenTelemetry.PersistentStorage.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "QuBc6e7M4Skvbc+eTQGSmrcoho7lSkHLT5ngoSsVeeT8OXLpSUETNcuRPW8F5drTPTzzTKQ98C5AhKO/pjpTJg=="
+      },
+      "OpenTelemetry.PersistentStorage.FileSystem": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "ys0l9vL0/wOV9p/iuyDeemjX+d8iH4yjaYA1IcmyQUw0xsxx0I3hQm7tN3FnuRPsmPtrohiLtp31hO1BcrhQ+A==",
+        "dependencies": {
+          "OpenTelemetry.PersistentStorage.Abstractions": "1.0.2"
+        }
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -549,6 +562,7 @@
       "ftgo.auth.client": {
         "type": "Project",
         "dependencies": {
+          "Azure.Monitor.OpenTelemetry.Exporter": "[1.5.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.7, )",
           "Microsoft.Extensions.Http": "[10.0.7, )",
           "Microsoft.Extensions.Http.Resilience": "[10.5.0, )",
@@ -558,6 +572,18 @@
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )"
+        }
+      },
+      "Azure.Monitor.OpenTelemetry.Exporter": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.0, )",
+        "resolved": "1.5.0",
+        "contentHash": "7YgW82V13PwhjrlaN2Nbu9UIvYMzZxjgV9TYqK34PK+81IWsDwPO3vBhyeHYpDBwKWm7wqHp1c3VVX5DN4G2WA==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "OpenTelemetry": "1.14.0",
+          "OpenTelemetry.Extensions.Hosting": "1.14.0",
+          "OpenTelemetry.PersistentStorage.FileSystem": "1.0.2"
         }
       },
       "Microsoft.Extensions.Http": {

--- a/src/Ftgo.ApiGateway/Program.cs
+++ b/src/Ftgo.ApiGateway/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddEntraAuth(builder.Configuration, auth =>
 builder.Services.AddEntraAuthWebTelemetry("Ftgo.ApiGateway");
 builder.Services.AddEntraAuthProblemDetails();
 builder.Services.AddEntraAuthOpenApi(builder.Configuration, "orders.read");
+builder.Services.AddHealthChecks();
 
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddControllers();
@@ -23,4 +24,5 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
 app.MapEntraAuthScalar(builder.Configuration, "orders.read");
+app.MapHealthChecks("/health");
 await app.RunAsync();

--- a/src/Ftgo.ApiGateway/packages.lock.json
+++ b/src/Ftgo.ApiGateway/packages.lock.json
@@ -283,6 +283,19 @@
           "OpenTelemetry.Api": "1.15.3"
         }
       },
+      "OpenTelemetry.PersistentStorage.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "QuBc6e7M4Skvbc+eTQGSmrcoho7lSkHLT5ngoSsVeeT8OXLpSUETNcuRPW8F5drTPTzzTKQ98C5AhKO/pjpTJg=="
+      },
+      "OpenTelemetry.PersistentStorage.FileSystem": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "ys0l9vL0/wOV9p/iuyDeemjX+d8iH4yjaYA1IcmyQUw0xsxx0I3hQm7tN3FnuRPsmPtrohiLtp31hO1BcrhQ+A==",
+        "dependencies": {
+          "OpenTelemetry.PersistentStorage.Abstractions": "1.0.2"
+        }
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -351,6 +364,7 @@
       "ftgo.auth.client": {
         "type": "Project",
         "dependencies": {
+          "Azure.Monitor.OpenTelemetry.Exporter": "[1.5.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.5.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
@@ -365,6 +379,18 @@
         "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
         "dependencies": {
           "Azure.Core": "1.53.0"
+        }
+      },
+      "Azure.Monitor.OpenTelemetry.Exporter": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.0, )",
+        "resolved": "1.5.0",
+        "contentHash": "7YgW82V13PwhjrlaN2Nbu9UIvYMzZxjgV9TYqK34PK+81IWsDwPO3vBhyeHYpDBwKWm7wqHp1c3VVX5DN4G2WA==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "OpenTelemetry": "1.14.0",
+          "OpenTelemetry.Extensions.Hosting": "1.14.0",
+          "OpenTelemetry.PersistentStorage.FileSystem": "1.0.2"
         }
       },
       "Azure.Security.KeyVault.Certificates": {

--- a/src/Ftgo.Auth.Client/Ftgo.Auth.Client.csproj
+++ b/src/Ftgo.Auth.Client/Ftgo.Auth.Client.csproj
@@ -16,5 +16,6 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
   </ItemGroup>
 </Project>

--- a/src/Ftgo.Auth.Client/TelemetryExtensions.cs
+++ b/src/Ftgo.Auth.Client/TelemetryExtensions.cs
@@ -1,3 +1,4 @@
+using Azure.Monitor.OpenTelemetry.Exporter;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -5,7 +6,10 @@ using OpenTelemetry.Trace;
 
 namespace Ftgo.Auth;
 
-/// <summary>OpenTelemetry traces + metrics for worker processes. The OTLP exporter is enabled only when <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is set, so local runs without a collector don't fail.</summary>
+/// <summary>OpenTelemetry traces + metrics for worker processes. Exporters are conditionally registered:
+/// the OTLP exporter activates when <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is set, the Azure Monitor
+/// exporter activates when <c>APPLICATIONINSIGHTS_CONNECTION_STRING</c> is set. Local runs without
+/// either env var don't fail.</summary>
 public static class TelemetryExtensions
 {
     public static IServiceCollection AddEntraAuthTelemetry(
@@ -17,6 +21,8 @@ public static class TelemetryExtensions
 
         var hasOtlp = !string.IsNullOrWhiteSpace(
             Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT"));
+        var aiConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+        var hasAzureMonitor = !string.IsNullOrWhiteSpace(aiConnectionString);
 
         services
             .AddOpenTelemetry()
@@ -25,12 +31,14 @@ public static class TelemetryExtensions
             {
                 t.AddHttpClientInstrumentation();
                 if (hasOtlp) t.AddOtlpExporter();
+                if (hasAzureMonitor) t.AddAzureMonitorTraceExporter(o => o.ConnectionString = aiConnectionString);
             })
             .WithMetrics(m =>
             {
                 m.AddHttpClientInstrumentation()
                  .AddRuntimeInstrumentation();
                 if (hasOtlp) m.AddOtlpExporter();
+                if (hasAzureMonitor) m.AddAzureMonitorMetricExporter(o => o.ConnectionString = aiConnectionString);
             });
 
         return services;

--- a/src/Ftgo.Auth.Client/packages.lock.json
+++ b/src/Ftgo.Auth.Client/packages.lock.json
@@ -8,6 +8,18 @@
         "resolved": "1.6.0",
         "contentHash": "/Xfs9H3UMfEv64cwT+C/JrTRp4w08BmPuFbj0ageadCHpx6rxYJxAU2C6sEqRFG22xmGk5cX9ewzoiiehWVHOw=="
       },
+      "Azure.Monitor.OpenTelemetry.Exporter": {
+        "type": "Direct",
+        "requested": "[1.5.0, )",
+        "resolved": "1.5.0",
+        "contentHash": "7YgW82V13PwhjrlaN2Nbu9UIvYMzZxjgV9TYqK34PK+81IWsDwPO3vBhyeHYpDBwKWm7wqHp1c3VVX5DN4G2WA==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "OpenTelemetry": "1.14.0",
+          "OpenTelemetry.Extensions.Hosting": "1.14.0",
+          "OpenTelemetry.PersistentStorage.FileSystem": "1.0.2"
+        }
+      },
       "Meziantou.Analyzer": {
         "type": "Direct",
         "requested": "[3.0.52, )",
@@ -149,6 +161,21 @@
         "requested": "[10.24.0.138807, )",
         "resolved": "10.24.0.138807",
         "contentHash": "+ZEa1+KhNSulMSatpffgHnovbLGtYL9oukMh8uQp8RBDnPOjEFzvECSa4kfu1D4PJxErksiGOQQ+kDeao1x9jQ=="
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.50.0",
+        "contentHash": "GBNKZEhdIbTXxedvD3R7I/yDVFX9jJJEz02kCziFSJxspSQ5RMHc3GktulJ1s7+ffXaXD7kMgrtdQTaggyInLw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.ClientModel": "1.8.0",
+          "System.Memory.Data": "8.0.1"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -494,6 +521,19 @@
           "OpenTelemetry.Api": "1.15.3"
         }
       },
+      "OpenTelemetry.PersistentStorage.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "QuBc6e7M4Skvbc+eTQGSmrcoho7lSkHLT5ngoSsVeeT8OXLpSUETNcuRPW8F5drTPTzzTKQ98C5AhKO/pjpTJg=="
+      },
+      "OpenTelemetry.PersistentStorage.FileSystem": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "ys0l9vL0/wOV9p/iuyDeemjX+d8iH4yjaYA1IcmyQUw0xsxx0I3hQm7tN3FnuRPsmPtrohiLtp31hO1BcrhQ+A==",
+        "dependencies": {
+          "OpenTelemetry.PersistentStorage.Abstractions": "1.0.2"
+        }
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -518,10 +558,24 @@
           "System.Threading.RateLimiting": "8.0.0"
         }
       },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.8.0",
+        "contentHash": "AqRzhn0v29GGGLj/Z6gKq4lGNtvPHT4nHdG5PDJh9IfVjv/nYUVmX11hwwws1vDFeIAzrvmn0dPu8IjLtu6fAw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.Memory.Data": "8.0.1"
+        }
+      },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "WbmDLeTPYhEzXhvYVioTVn/D1XX6bovyny9n5p8Zxtf03+eY385RB818teZm6n+fA63iZNvng0/Np4tLuhkMhQ=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
       },
       "System.Threading.RateLimiting": {
         "type": "Transitive",

--- a/src/Ftgo.Auth/packages.lock.json
+++ b/src/Ftgo.Auth/packages.lock.json
@@ -310,6 +310,19 @@
           "OpenTelemetry.Api": "1.15.3"
         }
       },
+      "OpenTelemetry.PersistentStorage.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "QuBc6e7M4Skvbc+eTQGSmrcoho7lSkHLT5ngoSsVeeT8OXLpSUETNcuRPW8F5drTPTzzTKQ98C5AhKO/pjpTJg=="
+      },
+      "OpenTelemetry.PersistentStorage.FileSystem": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "ys0l9vL0/wOV9p/iuyDeemjX+d8iH4yjaYA1IcmyQUw0xsxx0I3hQm7tN3FnuRPsmPtrohiLtp31hO1BcrhQ+A==",
+        "dependencies": {
+          "OpenTelemetry.PersistentStorage.Abstractions": "1.0.2"
+        }
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -366,6 +379,7 @@
       "ftgo.auth.client": {
         "type": "Project",
         "dependencies": {
+          "Azure.Monitor.OpenTelemetry.Exporter": "[1.5.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.5.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
@@ -380,6 +394,18 @@
         "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
         "dependencies": {
           "Azure.Core": "1.53.0"
+        }
+      },
+      "Azure.Monitor.OpenTelemetry.Exporter": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.0, )",
+        "resolved": "1.5.0",
+        "contentHash": "7YgW82V13PwhjrlaN2Nbu9UIvYMzZxjgV9TYqK34PK+81IWsDwPO3vBhyeHYpDBwKWm7wqHp1c3VVX5DN4G2WA==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "OpenTelemetry": "1.14.0",
+          "OpenTelemetry.Extensions.Hosting": "1.14.0",
+          "OpenTelemetry.PersistentStorage.FileSystem": "1.0.2"
         }
       },
       "Azure.Security.KeyVault.Certificates": {

--- a/src/Ftgo.DeliveryService/packages.lock.json
+++ b/src/Ftgo.DeliveryService/packages.lock.json
@@ -473,6 +473,19 @@
           "OpenTelemetry.Api": "1.15.3"
         }
       },
+      "OpenTelemetry.PersistentStorage.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "QuBc6e7M4Skvbc+eTQGSmrcoho7lSkHLT5ngoSsVeeT8OXLpSUETNcuRPW8F5drTPTzzTKQ98C5AhKO/pjpTJg=="
+      },
+      "OpenTelemetry.PersistentStorage.FileSystem": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "ys0l9vL0/wOV9p/iuyDeemjX+d8iH4yjaYA1IcmyQUw0xsxx0I3hQm7tN3FnuRPsmPtrohiLtp31hO1BcrhQ+A==",
+        "dependencies": {
+          "OpenTelemetry.PersistentStorage.Abstractions": "1.0.2"
+        }
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -531,6 +544,7 @@
       "ftgo.auth.client": {
         "type": "Project",
         "dependencies": {
+          "Azure.Monitor.OpenTelemetry.Exporter": "[1.5.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.7, )",
           "Microsoft.Extensions.Http": "[10.0.7, )",
           "Microsoft.Extensions.Http.Resilience": "[10.5.0, )",
@@ -540,6 +554,18 @@
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )"
+        }
+      },
+      "Azure.Monitor.OpenTelemetry.Exporter": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.0, )",
+        "resolved": "1.5.0",
+        "contentHash": "7YgW82V13PwhjrlaN2Nbu9UIvYMzZxjgV9TYqK34PK+81IWsDwPO3vBhyeHYpDBwKWm7wqHp1c3VVX5DN4G2WA==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "OpenTelemetry": "1.14.0",
+          "OpenTelemetry.Extensions.Hosting": "1.14.0",
+          "OpenTelemetry.PersistentStorage.FileSystem": "1.0.2"
         }
       },
       "Microsoft.Extensions.Http": {

--- a/src/Ftgo.KitchenService/packages.lock.json
+++ b/src/Ftgo.KitchenService/packages.lock.json
@@ -473,6 +473,19 @@
           "OpenTelemetry.Api": "1.15.3"
         }
       },
+      "OpenTelemetry.PersistentStorage.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "QuBc6e7M4Skvbc+eTQGSmrcoho7lSkHLT5ngoSsVeeT8OXLpSUETNcuRPW8F5drTPTzzTKQ98C5AhKO/pjpTJg=="
+      },
+      "OpenTelemetry.PersistentStorage.FileSystem": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "ys0l9vL0/wOV9p/iuyDeemjX+d8iH4yjaYA1IcmyQUw0xsxx0I3hQm7tN3FnuRPsmPtrohiLtp31hO1BcrhQ+A==",
+        "dependencies": {
+          "OpenTelemetry.PersistentStorage.Abstractions": "1.0.2"
+        }
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -531,6 +544,7 @@
       "ftgo.auth.client": {
         "type": "Project",
         "dependencies": {
+          "Azure.Monitor.OpenTelemetry.Exporter": "[1.5.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.7, )",
           "Microsoft.Extensions.Http": "[10.0.7, )",
           "Microsoft.Extensions.Http.Resilience": "[10.5.0, )",
@@ -540,6 +554,18 @@
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )"
+        }
+      },
+      "Azure.Monitor.OpenTelemetry.Exporter": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.0, )",
+        "resolved": "1.5.0",
+        "contentHash": "7YgW82V13PwhjrlaN2Nbu9UIvYMzZxjgV9TYqK34PK+81IWsDwPO3vBhyeHYpDBwKWm7wqHp1c3VVX5DN4G2WA==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "OpenTelemetry": "1.14.0",
+          "OpenTelemetry.Extensions.Hosting": "1.14.0",
+          "OpenTelemetry.PersistentStorage.FileSystem": "1.0.2"
         }
       },
       "Microsoft.Extensions.Http": {

--- a/src/Ftgo.NotificationService/packages.lock.json
+++ b/src/Ftgo.NotificationService/packages.lock.json
@@ -87,6 +87,21 @@
         "resolved": "10.24.0.138807",
         "contentHash": "+ZEa1+KhNSulMSatpffgHnovbLGtYL9oukMh8uQp8RBDnPOjEFzvECSa4kfu1D4PJxErksiGOQQ+kDeao1x9jQ=="
       },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.50.0",
+        "contentHash": "GBNKZEhdIbTXxedvD3R7I/yDVFX9jJJEz02kCziFSJxspSQ5RMHc3GktulJ1s7+ffXaXD7kMgrtdQTaggyInLw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.ClientModel": "1.8.0",
+          "System.Memory.Data": "8.0.1"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -436,6 +451,19 @@
           "OpenTelemetry.Api": "1.15.3"
         }
       },
+      "OpenTelemetry.PersistentStorage.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "QuBc6e7M4Skvbc+eTQGSmrcoho7lSkHLT5ngoSsVeeT8OXLpSUETNcuRPW8F5drTPTzzTKQ98C5AhKO/pjpTJg=="
+      },
+      "OpenTelemetry.PersistentStorage.FileSystem": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "ys0l9vL0/wOV9p/iuyDeemjX+d8iH4yjaYA1IcmyQUw0xsxx0I3hQm7tN3FnuRPsmPtrohiLtp31hO1BcrhQ+A==",
+        "dependencies": {
+          "OpenTelemetry.PersistentStorage.Abstractions": "1.0.2"
+        }
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -460,10 +488,24 @@
           "System.Threading.RateLimiting": "8.0.0"
         }
       },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.8.0",
+        "contentHash": "AqRzhn0v29GGGLj/Z6gKq4lGNtvPHT4nHdG5PDJh9IfVjv/nYUVmX11hwwws1vDFeIAzrvmn0dPu8IjLtu6fAw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.Memory.Data": "8.0.1"
+        }
+      },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "WbmDLeTPYhEzXhvYVioTVn/D1XX6bovyny9n5p8Zxtf03+eY385RB818teZm6n+fA63iZNvng0/Np4tLuhkMhQ=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
       },
       "System.Threading.RateLimiting": {
         "type": "Transitive",
@@ -473,6 +515,7 @@
       "ftgo.auth.client": {
         "type": "Project",
         "dependencies": {
+          "Azure.Monitor.OpenTelemetry.Exporter": "[1.5.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.7, )",
           "Microsoft.Extensions.Http": "[10.0.7, )",
           "Microsoft.Extensions.Http.Resilience": "[10.5.0, )",
@@ -482,6 +525,18 @@
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )"
+        }
+      },
+      "Azure.Monitor.OpenTelemetry.Exporter": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.0, )",
+        "resolved": "1.5.0",
+        "contentHash": "7YgW82V13PwhjrlaN2Nbu9UIvYMzZxjgV9TYqK34PK+81IWsDwPO3vBhyeHYpDBwKWm7wqHp1c3VVX5DN4G2WA==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "OpenTelemetry": "1.14.0",
+          "OpenTelemetry.Extensions.Hosting": "1.14.0",
+          "OpenTelemetry.PersistentStorage.FileSystem": "1.0.2"
         }
       },
       "Microsoft.Extensions.Http": {

--- a/src/Ftgo.OrderService/Program.cs
+++ b/src/Ftgo.OrderService/Program.cs
@@ -7,6 +7,7 @@ builder.Services.AddEntraAuthWebTelemetry("Ftgo.OrderService");
 builder.Services.AddEntraAuthProblemDetails();
 builder.Services.AddOpenApi();
 builder.Services.AddControllers();
+builder.Services.AddHealthChecks();
 
 var app = builder.Build();
 app.UseEntraAuthProblemDetails();
@@ -15,4 +16,5 @@ app.UseAuthorization();
 app.MapControllers();
 app.MapOpenApi();
 app.MapScalarApiReference();
+app.MapHealthChecks("/health");
 await app.RunAsync();

--- a/src/Ftgo.OrderService/packages.lock.json
+++ b/src/Ftgo.OrderService/packages.lock.json
@@ -283,6 +283,19 @@
           "OpenTelemetry.Api": "1.15.3"
         }
       },
+      "OpenTelemetry.PersistentStorage.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "QuBc6e7M4Skvbc+eTQGSmrcoho7lSkHLT5ngoSsVeeT8OXLpSUETNcuRPW8F5drTPTzzTKQ98C5AhKO/pjpTJg=="
+      },
+      "OpenTelemetry.PersistentStorage.FileSystem": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "ys0l9vL0/wOV9p/iuyDeemjX+d8iH4yjaYA1IcmyQUw0xsxx0I3hQm7tN3FnuRPsmPtrohiLtp31hO1BcrhQ+A==",
+        "dependencies": {
+          "OpenTelemetry.PersistentStorage.Abstractions": "1.0.2"
+        }
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -351,6 +364,7 @@
       "ftgo.auth.client": {
         "type": "Project",
         "dependencies": {
+          "Azure.Monitor.OpenTelemetry.Exporter": "[1.5.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.5.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
@@ -365,6 +379,18 @@
         "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
         "dependencies": {
           "Azure.Core": "1.53.0"
+        }
+      },
+      "Azure.Monitor.OpenTelemetry.Exporter": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.0, )",
+        "resolved": "1.5.0",
+        "contentHash": "7YgW82V13PwhjrlaN2Nbu9UIvYMzZxjgV9TYqK34PK+81IWsDwPO3vBhyeHYpDBwKWm7wqHp1c3VVX5DN4G2WA==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "OpenTelemetry": "1.14.0",
+          "OpenTelemetry.Extensions.Hosting": "1.14.0",
+          "OpenTelemetry.PersistentStorage.FileSystem": "1.0.2"
         }
       },
       "Azure.Security.KeyVault.Certificates": {

--- a/src/Ftgo.RestaurantService/Program.cs
+++ b/src/Ftgo.RestaurantService/Program.cs
@@ -7,6 +7,7 @@ builder.Services.AddEntraAuthWebTelemetry("Ftgo.RestaurantService");
 builder.Services.AddEntraAuthProblemDetails();
 builder.Services.AddOpenApi();
 builder.Services.AddControllers();
+builder.Services.AddHealthChecks();
 
 var app = builder.Build();
 app.UseEntraAuthProblemDetails();
@@ -15,4 +16,5 @@ app.UseAuthorization();
 app.MapControllers();
 app.MapOpenApi();
 app.MapScalarApiReference();
+app.MapHealthChecks("/health");
 await app.RunAsync();

--- a/src/Ftgo.RestaurantService/packages.lock.json
+++ b/src/Ftgo.RestaurantService/packages.lock.json
@@ -283,6 +283,19 @@
           "OpenTelemetry.Api": "1.15.3"
         }
       },
+      "OpenTelemetry.PersistentStorage.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "QuBc6e7M4Skvbc+eTQGSmrcoho7lSkHLT5ngoSsVeeT8OXLpSUETNcuRPW8F5drTPTzzTKQ98C5AhKO/pjpTJg=="
+      },
+      "OpenTelemetry.PersistentStorage.FileSystem": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "ys0l9vL0/wOV9p/iuyDeemjX+d8iH4yjaYA1IcmyQUw0xsxx0I3hQm7tN3FnuRPsmPtrohiLtp31hO1BcrhQ+A==",
+        "dependencies": {
+          "OpenTelemetry.PersistentStorage.Abstractions": "1.0.2"
+        }
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -351,6 +364,7 @@
       "ftgo.auth.client": {
         "type": "Project",
         "dependencies": {
+          "Azure.Monitor.OpenTelemetry.Exporter": "[1.5.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.5.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
@@ -365,6 +379,18 @@
         "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
         "dependencies": {
           "Azure.Core": "1.53.0"
+        }
+      },
+      "Azure.Monitor.OpenTelemetry.Exporter": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.0, )",
+        "resolved": "1.5.0",
+        "contentHash": "7YgW82V13PwhjrlaN2Nbu9UIvYMzZxjgV9TYqK34PK+81IWsDwPO3vBhyeHYpDBwKWm7wqHp1c3VVX5DN4G2WA==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "OpenTelemetry": "1.14.0",
+          "OpenTelemetry.Extensions.Hosting": "1.14.0",
+          "OpenTelemetry.PersistentStorage.FileSystem": "1.0.2"
         }
       },
       "Azure.Security.KeyVault.Certificates": {

--- a/tests/Ftgo.Auth.Tests/packages.lock.json
+++ b/tests/Ftgo.Auth.Tests/packages.lock.json
@@ -693,6 +693,19 @@
           "OpenTelemetry.Api": "1.15.3"
         }
       },
+      "OpenTelemetry.PersistentStorage.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "QuBc6e7M4Skvbc+eTQGSmrcoho7lSkHLT5ngoSsVeeT8OXLpSUETNcuRPW8F5drTPTzzTKQ98C5AhKO/pjpTJg=="
+      },
+      "OpenTelemetry.PersistentStorage.FileSystem": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "ys0l9vL0/wOV9p/iuyDeemjX+d8iH4yjaYA1IcmyQUw0xsxx0I3hQm7tN3FnuRPsmPtrohiLtp31hO1BcrhQ+A==",
+        "dependencies": {
+          "OpenTelemetry.PersistentStorage.Abstractions": "1.0.2"
+        }
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -857,6 +870,7 @@
       "ftgo.auth.client": {
         "type": "Project",
         "dependencies": {
+          "Azure.Monitor.OpenTelemetry.Exporter": "[1.5.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.7, )",
           "Microsoft.Extensions.Http": "[10.0.7, )",
           "Microsoft.Extensions.Http.Resilience": "[10.5.0, )",
@@ -875,6 +889,18 @@
         "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
         "dependencies": {
           "Azure.Core": "1.53.0"
+        }
+      },
+      "Azure.Monitor.OpenTelemetry.Exporter": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.0, )",
+        "resolved": "1.5.0",
+        "contentHash": "7YgW82V13PwhjrlaN2Nbu9UIvYMzZxjgV9TYqK34PK+81IWsDwPO3vBhyeHYpDBwKWm7wqHp1c3VVX5DN4G2WA==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "OpenTelemetry": "1.14.0",
+          "OpenTelemetry.Extensions.Hosting": "1.14.0",
+          "OpenTelemetry.PersistentStorage.FileSystem": "1.0.2"
         }
       },
       "Azure.Security.KeyVault.Certificates": {


### PR DESCRIPTION
Implements free-tier multi-environment cloud deployment for the FTGO sample. Pushes to \`main\` build images, deploy to dev, promote to ppe, then prod (with required-reviewer gate). \$0/mo idle, ~\$3-5/mo with prod always-on.

## What's in here

| Phase | Files |
|---|---|
| 1 — Containerize | \`Dockerfile\` (parameterized, chiseled, ~95 MB), \`.dockerignore\` |
| 2 — Multi-env Bicep | \`infra/bicep/azure.bicep\` + 7 modules, 3 env bicepparam files; \`main.bicep\` extended for env-suffixed Entra apps |
| 3 — CD workflow | \`.github/workflows/cd.yml\` (build → dev → ppe → prod), \`cd-cleanup.yml\` (nightly scale-reset) |
| 4 — Bootstrap | \`scripts/bootstrap-env.sh\` (RG, MI, federated cred, RBAC, GH Environment) |
| 5 — Provisioning | \`scripts/provision-apps.sh\` (per-env Entra app regs, ACA-MI ↔ app-reg FICs) |
| 6 — Observability | Azure Monitor OTel exporter (conditional on env var), \`/health\` endpoints on web apps, ingress split for headless workers |
| 7 — Docs | \`docs/deploy-cloud.md\`, \`docs/environments.md\`, README \"Deploy to the cloud\" + CD badge |

## Architecture highlights

- **Single image, build once, promote many** — \`:sha-XXX\` tags, same digest deployed to all 3 envs.
- **Public ghcr.io images** — anonymous pull from ACA, no registry credentials.
- **OIDC only** — federated credential subject \`repo:OWNER/REPO:environment:{env}\`. Zero stored secrets.
- **CD identity is ARM-scoped** — Entra app provisioning is out-of-band via \`provision-apps.sh\` (one-time per env), so the CD MI doesn't need Microsoft Graph perms.
- **Web vs worker split** — 3 web apps get HTTP ingress + scale-to-zero + \`/health\` probe; 4 workers run headless with CPU-utilization scaling and min=1.
- **System MI on every ACA app** — federated to the matching Entra app reg so services use \`SignedAssertionFromManagedIdentity\` (already wired in \`appsettings.json\`).
- **App Insights exporter** — conditional on \`APPLICATIONINSIGHTS_CONNECTION_STRING\` (injected by Bicep at deploy time). Existing OTLP exporter path preserved for local-dev.

## Verification

- \`dotnet build\` — clean, 0 warnings
- \`dotnet test\` — 24/24 pass
- \`dotnet format --verify-no-changes\` — clean
- \`az bicep build\` + \`az bicep lint\` — clean on all modules and bicepparam files
- \`actionlint\` — clean on all 4 workflows
- \`shellcheck\` — clean on \`bootstrap-env.sh\` and \`provision-apps.sh\`

End-to-end Azure deploy is **not** exercised in CI — that requires bootstrap (a manual one-time per-env step). Once a maintainer runs \`scripts/bootstrap-env.sh ENV=dev\`, subsequent pushes to \`main\` will auto-deploy.

## What I deliberately did *not* do

- **No smoke tests in CD.** Real teams verify production from telemetry (App Insights live metrics + dependency map + alerts), not curl-in-CI. Each env exposes its own Scalar UI for manual verification.
- **No \`if: false\` dead steps.** Earlier draft kept the Entra-app deploy step in \`cd.yml\` disabled; removed entirely — the documented path is \`provision-apps.sh\`.
- **No conversion of \`EntraAuthOptionsValidator\` to \`[OptionsValidator]\`** — its cross-property invariant can't be expressed via the source generator.
- **No custom domain.** Built-in \`*.azurecontainerapps.io\` is used.

## Follow-ups (intentionally out of scope)

- Production reviewer is hard-coded to the repo owner in \`bootstrap-env.sh\`; override via \`gh api\` PATCH if the team grows.
- \`workflow_dispatch\` with empty \`imageTag\` rebuilds from HEAD. A future iteration could resolve \"latest dev image tag\" from the dev RG for true promotion semantics on dispatch.

Closes the cloud-deployment line of work tracked under todos \`cloud-01\` through \`cloud-10\`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>