### PR TITLE
fix(deploy): drop --locked-mode from Dockerfile restore (NU1004)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,13 @@ COPY src/Ftgo.Auth/packages.lock.json                       src/Ftgo.Auth/
 COPY src/Ftgo.Auth.Client/packages.lock.json                src/Ftgo.Auth.Client/
 
 RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet restore -a "${TARGETARCH:-amd64}" --locked-mode src/${PROJECT}/${PROJECT}.csproj
+    dotnet restore -a "${TARGETARCH:-amd64}" src/${PROJECT}/${PROJECT}.csproj
+# NOTE: --locked-mode intentionally NOT used here. CI (`ci.yml`) restores the
+# whole solution with --locked-mode on every PR/push, so lock-file integrity
+# is already enforced before any image is built. Adding it here would conflict
+# with the per-RID restore (lock files don't include runtime identifiers, so
+# `-a $TARGETARCH` produces an RID set the lock file never recorded → NU1004).
+# Matches dotnet/dotnet-docker official samples.
 
 # ─── Stage 2: publish ───
 FROM restore AS publish


### PR DESCRIPTION
## Why

After PR #18 fixed the empty-`TARGETARCH` issue, the post-merge CD on `main` (run [24936053110](https://github.com/mghabin/entra-auth-patterns-dotnet/actions/runs/24936053110)) failed with a new error in all 7 `build-images` matrix jobs:

```
NU1004: The project's runtime identifiers have changed from. Project's runtime identifiers: linux-x64, lock file's runtime identifiers .
```

## Root cause

The `packages.lock.json` files were generated without a `runtimes` key (verified: only `dependencies` + `version` keys present). When the Dockerfile passes `-a amd64` to `dotnet restore`, the project's effective RID becomes `linux-x64` — but the lock file has no RIDs recorded → mismatch under `--locked-mode`.

## Fix

Drop `--locked-mode` from the **Dockerfile** restore step.

Lock-file integrity is **already enforced** by CI (`ci.yml`):
```
dotnet restore EntraAuthPatterns.slnx --locked-mode
```
This runs on every PR and every push to `main` *before* any image is built. So we don't lose any supply-chain guarantee — we just stop double-enforcing it in a context that conflicts with per-RID restore.

This matches Microsoft's official `dotnet/dotnet-docker` samples, which restore in Dockerfiles **without** `--locked-mode`.

## Alternatives considered

| Approach | Verdict |
|---|---|
| Regenerate lock files with `-a x64` | Would force every dev to also restore with `-a x64` locally; breaks default `dotnet build` |
| Add `<RuntimeIdentifiers>` to `Directory.Build.props` | Would change build behavior for all projects (incl. test/lib projects); larger blast radius |
| Drop `--locked-mode` from Dockerfile (this PR) | Minimal change, matches MS samples, integrity still enforced in CI |
