### PR TITLE
fix(deploy): copy .editorconfig into Docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ ARG TARGETARCH
 WORKDIR /src
 
 # Central props affect every restore — copy first.
-COPY Directory.Build.props Directory.Packages.props EntraAuthPatterns.slnx ./
+# .editorconfig is required so analyzers (Meziantou, etc.) honor per-rule
+# severity overrides during `dotnet publish` inside the container.
+COPY Directory.Build.props Directory.Packages.props .editorconfig EntraAuthPatterns.slnx ./
 
 # Copy ALL service csprojs (small files; this layer is cached as long as none of them change).
 # Including all of them lets us share one restore layer across services that ProjectReference each other.


### PR DESCRIPTION
## Why

After PR #19 (drop `--locked-mode`), CD on main failed in all 7 `build-images` jobs with:
```
error MA0048: File name must match type name
error MA0004: Use Task.ConfigureAwait(false)
```
during `dotnet publish` inside the Docker build.

## Root cause

`.editorconfig` at the repo root sets `MA0048 = none` and `MA0004 = suggestion`. Without it inside the build container, Meziantou.Analyzer falls back to default severities → `TreatWarningsAsErrors=true` (in `Directory.Build.props`) turns those into errors.

CI passes because `dotnet build` runs from the workspace root with `.editorconfig` present.

## Fix

Add `.editorconfig` to the early COPY layer alongside `Directory.Build.props` / `Directory.Packages.props`.
