### PR TITLE
Refactor bootstrap: declarative Bicep for Azure side, slim gh wrapper for GitHub side

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,19 @@ jobs:
 
       - name: Bicep build (lints templates)
         run: |
-          az bicep build --file infra/bicep/main.bicep --outdir /tmp/bicep-out
-          echo "main.bicep + modules built clean"
+          az bicep build --file infra/bicep/main.bicep      --outdir /tmp/bicep-out
+          az bicep build --file infra/bicep/azure.bicep     --outdir /tmp/bicep-out
+          az bicep build --file infra/bicep/bootstrap.bicep --outdir /tmp/bicep-out
+          echo "main.bicep + azure.bicep + bootstrap.bicep + modules built clean"
 
       - name: Bicep build-params
         env:
           AZURE_TENANT_ID: 00000000-0000-0000-0000-000000000000
+          GH_OWNER:        mghabin
+          GH_REPO:         entra-auth-patterns-dotnet
         run: |
-          az bicep build-params --file infra/bicep/main.bicepparam --outfile /tmp/bicep-out/main.parameters.json
-          echo "main.bicepparam compiled clean"
+          az bicep build-params --file infra/bicep/main.bicepparam          --outfile /tmp/bicep-out/main.parameters.json
+          for env in dev ppe prod; do
+            az bicep build-params --file "infra/bicep/bootstrap.${env}.bicepparam" --outfile "/tmp/bicep-out/bootstrap.${env}.parameters.json"
+          done
+          echo "all bicepparam files compiled clean"

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ appsettings.*.local.json
 
 # Compiled Bicep ARM output
 infra/bicep/*.json
+.bicep-out/
+infra/bicep/modules/*.json

--- a/infra/bicep/bootstrap.bicep
+++ b/infra/bicep/bootstrap.bicep
@@ -1,0 +1,71 @@
+metadata name        = 'bootstrap'
+metadata description = 'Day-0 per-environment bootstrap: creates rg-ftgo-{env}-{location}, the CD UAMI, its GitHub-Actions OIDC federated credential, and RG-scoped RBAC. Run once per env by an Azure Owner from a developer machine; subsequent deploys use the UAMI. The GitHub side (Environment, env vars, repo secret) is configured by scripts/bootstrap-env.sh from this template`s outputs.'
+
+extension az
+
+targetScope = 'subscription'
+
+@description('Logical environment name; controls RG/MI naming and the federated subject.')
+@allowed([ 'dev', 'ppe', 'prod' ])
+param environmentName string
+
+@description('Azure region. Defaults to eastus (largest free quota).')
+param location string = 'eastus'
+
+@description('GitHub repo owner (org or user). Used in the OIDC subject claim.')
+param githubOwner string
+
+@description('GitHub repo name. Used in the OIDC subject claim.')
+param githubRepo string
+
+// ------- Naming (kept identical to the previous bootstrap-env.sh values) -------
+var rgName     = 'rg-ftgo-${environmentName}-${location}'
+var miName     = 'ftgo-${environmentName}-cd-mi'
+var ficName    = 'github-${environmentName}'
+var ficSubject = 'repo:${githubOwner}/${githubRepo}:environment:${environmentName}'
+
+// Built-in role-definition GUIDs.
+// Source: https://learn.microsoft.com/azure/role-based-access-control/built-in-roles
+var roles = {
+  Contributor:             'b24988ac-6180-42a0-ab88-20f7382dd24c'
+  UserAccessAdministrator: '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
+}
+
+// Prod also needs User Access Administrator so the deploy pipeline can grant
+// Key Vault RBAC to the per-app managed identities created by azure.bicep.
+var roleIds = environmentName == 'prod'
+  ? [ roles.Contributor, roles.UserAccessAdministrator ]
+  : [ roles.Contributor ]
+
+var tags = {
+  environment: environmentName
+  workload:    'ftgo'
+  managedBy:   'bicep'
+  purpose:     'cd-bootstrap'
+}
+
+resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name:     rgName
+  location: location
+  tags:     tags
+}
+
+module cdBootstrap 'modules/cd-bootstrap.bicep' = {
+  scope: resourceGroup(rg.name)
+  name:  'cd-bootstrap'
+  params: {
+    location:   location
+    miName:     miName
+    ficName:    ficName
+    ficSubject: ficSubject
+    roleIds:    roleIds
+    tags:       tags
+  }
+}
+
+output resourceGroupName string = rg.name
+output clientId          string = cdBootstrap.outputs.clientId
+output principalId       string = cdBootstrap.outputs.principalId
+output subscriptionId    string = subscription().subscriptionId
+output tenantId          string = subscription().tenantId
+output federatedSubject  string = ficSubject

--- a/infra/bicep/bootstrap.dev.bicepparam
+++ b/infra/bicep/bootstrap.dev.bicepparam
@@ -1,0 +1,9 @@
+// Day-0 bootstrap parameters for the dev environment.
+// Deploy via: ./scripts/bootstrap-env.sh ENV=dev
+
+using 'bootstrap.bicep'
+
+param environmentName = 'dev'
+param location        = 'eastus'
+param githubOwner     = readEnvironmentVariable('GH_OWNER', 'mghabin')
+param githubRepo      = readEnvironmentVariable('GH_REPO',  'entra-auth-patterns-dotnet')

--- a/infra/bicep/bootstrap.ppe.bicepparam
+++ b/infra/bicep/bootstrap.ppe.bicepparam
@@ -1,0 +1,9 @@
+// Day-0 bootstrap parameters for the ppe environment.
+// Deploy via: ./scripts/bootstrap-env.sh ENV=ppe
+
+using 'bootstrap.bicep'
+
+param environmentName = 'ppe'
+param location        = 'eastus'
+param githubOwner     = readEnvironmentVariable('GH_OWNER', 'mghabin')
+param githubRepo      = readEnvironmentVariable('GH_REPO',  'entra-auth-patterns-dotnet')

--- a/infra/bicep/bootstrap.prod.bicepparam
+++ b/infra/bicep/bootstrap.prod.bicepparam
@@ -1,0 +1,9 @@
+// Day-0 bootstrap parameters for the prod environment.
+// Deploy via: ./scripts/bootstrap-env.sh ENV=prod
+
+using 'bootstrap.bicep'
+
+param environmentName = 'prod'
+param location        = 'eastus'
+param githubOwner     = readEnvironmentVariable('GH_OWNER', 'mghabin')
+param githubRepo      = readEnvironmentVariable('GH_REPO',  'entra-auth-patterns-dotnet')

--- a/infra/bicep/modules/cd-bootstrap.bicep
+++ b/infra/bicep/modules/cd-bootstrap.bicep
@@ -1,0 +1,55 @@
+metadata name        = 'cd-bootstrap'
+metadata description = 'CD UAMI + GitHub-Actions federated identity credential + RG-scoped role assignments. Runs at resource-group scope from bootstrap.bicep.'
+
+extension az
+
+@description('Azure region for the managed identity.')
+param location string
+
+@description('User-assigned managed identity name.')
+param miName string
+
+@description('Federated identity credential name.')
+param ficName string
+
+@description('OIDC subject claim. Format: repo:OWNER/REPO:environment:ENV')
+param ficSubject string
+
+@description('Built-in role-definition GUIDs to assign to the UAMI at this RG scope.')
+param roleIds array
+
+@description('Tags applied to the UAMI.')
+param tags object = {}
+
+resource mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name:     miName
+  location: location
+  tags:     tags
+}
+
+resource fic 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = {
+  name:   ficName
+  parent: mi
+  properties: {
+    issuer:    'https://token.actions.githubusercontent.com'
+    subject:   ficSubject
+    audiences: [ 'api://AzureADTokenExchange' ]
+  }
+}
+
+// Deterministic GUID → idempotent re-runs (same scope+principal+role → same name).
+// Note: if the UAMI is ever DELETED and recreated with the same name, mi.id stays
+// stable but its principalId changes; you must also delete the old role assignments
+// before re-running, or Azure will reject the update as immutable.
+resource roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for roleId in roleIds: {
+  name: guid(resourceGroup().id, mi.id, roleId)
+  properties: {
+    principalId:      mi.properties.principalId
+    principalType:    'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleId)
+  }
+}]
+
+output clientId    string = mi.properties.clientId
+output principalId string = mi.properties.principalId
+output resourceId  string = mi.id

--- a/scripts/bootstrap-env.sh
+++ b/scripts/bootstrap-env.sh
@@ -1,21 +1,27 @@
 #!/usr/bin/env bash
 # scripts/bootstrap-env.sh — one-time per-environment bootstrap for the cloud CD pipeline.
 #
-# Provisions the bits the GitHub Actions cd.yml workflow assumes already exist:
-#   1. Resource group        rg-ftgo-${ENV}-eastus
-#   2. User-assigned MI      ftgo-${ENV}-cd-mi   (with GH OIDC federation)
-#   3. RBAC                  Contributor on the RG (+ User Access Admin for prod)
-#   4. GitHub Environment    ${ENV} (with required reviewer for prod)
-#   5. GH env vars           AZURE_CLIENT_ID, AZURE_SUBSCRIPTION_ID
-#   6. Repo secret           AZURE_TENANT_ID (one-time, shared across envs)
+# Azure side  (declarative): infra/bicep/bootstrap.bicep deploys
+#   1. Resource group       rg-ftgo-${ENV}-eastus
+#   2. User-assigned MI     ftgo-${ENV}-cd-mi
+#   3. Federated credential github-${ENV}  (subject: repo:OWNER/REPO:environment:ENV)
+#   4. RBAC                 Contributor on the RG (+ User Access Admin for prod)
 #
-# Idempotent: re-running on a bootstrapped env is a no-op.
+# GitHub side (imperative — outside Azure ARM):
+#   5. GitHub Environment   ${ENV} (with required reviewer for prod)
+#   6. GH env vars          AZURE_CLIENT_ID, AZURE_SUBSCRIPTION_ID
+#   7. Repo secret          AZURE_TENANT_ID (one-time, shared across envs)
+#
+# Idempotent: safe to re-run. Bicep deployment uses deterministic names; gh PUT
+# semantics upsert.
 #
 # Usage:
 #   ./scripts/bootstrap-env.sh ENV=dev
+#   ./scripts/bootstrap-env.sh ENV=ppe
 #   ./scripts/bootstrap-env.sh ENV=prod
 #
-# Prereqs: bash 4+, az CLI logged in to the target subscription, gh CLI authenticated to the repo, jq.
+# Prereqs: bash 4+, az CLI logged in to the target subscription with Owner role,
+# gh CLI authenticated to the repo, jq.
 
 set -euo pipefail
 
@@ -29,7 +35,7 @@ ENV=""
 for arg in "$@"; do
   case "$arg" in
     ENV=*) ENV="${arg#ENV=}" ;;
-    -h|--help) sed -n '2,18p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    -h|--help) sed -n '2,24p' "$0" | sed 's/^# \?//'; exit 0 ;;
     *) echo "unknown arg: $arg (expected ENV=dev|ppe|prod)" >&2; exit 2 ;;
   esac
 done
@@ -43,86 +49,44 @@ for tool in az gh jq; do
   command -v "$tool" >/dev/null || { echo "ERROR: '$tool' not on PATH" >&2; exit 1; }
 done
 
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GH_OWNER="${GH_OWNER:-$(gh repo view --json owner --jq .owner.login)}"
 GH_REPO="${GH_REPO:-$(gh repo view --json name --jq .name)}"
-SUB_ID="$(az account show --query id -o tsv)"
-TENANT_ID="$(az account show --query tenantId -o tsv)"
 LOCATION="${LOCATION:-eastus}"
-RG_NAME="rg-ftgo-${ENV}-${LOCATION}"
-MI_NAME="ftgo-${ENV}-cd-mi"
-FIC_NAME="github-${ENV}"
-FIC_SUBJECT="repo:${GH_OWNER}/${GH_REPO}:environment:${ENV}"
+TENANT_ID="$(az account show --query tenantId -o tsv)"
+SUB_ID="$(az account show --query id -o tsv)"
 
 echo "==> repo         : ${GH_OWNER}/${GH_REPO}"
 echo "==> subscription : ${SUB_ID}"
 echo "==> tenant       : ${TENANT_ID}"
-echo "==> env          : ${ENV}  (rg=${RG_NAME}, mi=${MI_NAME})"
+echo "==> env          : ${ENV}"
 echo
 
-# 1. Resource group
-echo "==> Resource group"
-if az group show --name "$RG_NAME" --only-show-errors --output none 2>/dev/null; then
-  echo "    $RG_NAME already exists"
-else
-  az group create --name "$RG_NAME" --location "$LOCATION" --only-show-errors --output none
-  echo "    created $RG_NAME"
-fi
-
-# 2. User-assigned managed identity
-echo "==> User-assigned managed identity"
-if az identity show --name "$MI_NAME" --resource-group "$RG_NAME" --only-show-errors --output none 2>/dev/null; then
-  echo "    $MI_NAME already exists"
-else
-  az identity create --name "$MI_NAME" --resource-group "$RG_NAME" --location "$LOCATION" --only-show-errors --output none
-  echo "    created $MI_NAME"
-fi
-MI_JSON=$(az identity show --name "$MI_NAME" --resource-group "$RG_NAME" -o json --only-show-errors)
-MI_CLIENT_ID=$(jq -r .clientId <<<"$MI_JSON")
-MI_PRINCIPAL_ID=$(jq -r .principalId <<<"$MI_JSON")
-echo "    clientId    = $MI_CLIENT_ID"
-echo "    principalId = $MI_PRINCIPAL_ID"
-
-# 3. Federated identity credential (GH Actions → MI)
-echo "==> Federated identity credential ($FIC_NAME)"
-if az identity federated-credential show \
-      --name "$FIC_NAME" --identity-name "$MI_NAME" --resource-group "$RG_NAME" \
-      --only-show-errors --output none 2>/dev/null; then
-  echo "    $FIC_NAME already exists"
-else
-  az identity federated-credential create \
-    --name "$FIC_NAME" \
-    --identity-name "$MI_NAME" \
-    --resource-group "$RG_NAME" \
-    --issuer "https://token.actions.githubusercontent.com" \
-    --subject "$FIC_SUBJECT" \
-    --audiences "api://AzureADTokenExchange" \
+# ---------- Azure side: infra/bicep/bootstrap.bicep ----------
+DEPLOY_NAME="bootstrap-${ENV}-$(date +%Y%m%d%H%M%S)"
+echo "==> Deploying infra/bicep/bootstrap.bicep ($DEPLOY_NAME)"
+GH_OWNER="$GH_OWNER" GH_REPO="$GH_REPO" \
+  az deployment sub create \
+    --name "$DEPLOY_NAME" \
+    --location "$LOCATION" \
+    --template-file "$ROOT/infra/bicep/bootstrap.bicep" \
+    --parameters    "$ROOT/infra/bicep/bootstrap.${ENV}.bicepparam" \
     --only-show-errors --output none
-  echo "    created (subject=$FIC_SUBJECT)"
-fi
 
-# 4. RBAC
-assign_role() {
-  local role="$1" scope="$2"
-  if az role assignment list --assignee "$MI_PRINCIPAL_ID" --role "$role" --scope "$scope" \
-        --only-show-errors -o tsv --query '[].id' 2>/dev/null | grep -q .; then
-    echo "    '$role' already assigned at $scope"
-  else
-    az role assignment create --assignee-object-id "$MI_PRINCIPAL_ID" \
-      --assignee-principal-type ServicePrincipal \
-      --role "$role" --scope "$scope" --only-show-errors --output none
-    echo "    granted '$role' at $scope"
-  fi
-}
-RG_SCOPE="/subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}"
-echo "==> Role assignments"
-assign_role "Contributor" "$RG_SCOPE"
-if [[ "$ENV" == "prod" ]]; then
-  assign_role "User Access Administrator" "$RG_SCOPE"
-fi
+OUTPUTS=$(az deployment sub show --name "$DEPLOY_NAME" --query properties.outputs -o json)
+RG_NAME=$(jq -r .resourceGroupName.value <<<"$OUTPUTS")
+MI_CLIENT_ID=$(jq -r .clientId.value         <<<"$OUTPUTS")
+DEPLOY_SUB_ID=$(jq -r .subscriptionId.value  <<<"$OUTPUTS")
+FIC_SUBJECT=$(jq -r .federatedSubject.value  <<<"$OUTPUTS")
+echo "    resourceGroup = $RG_NAME"
+echo "    clientId      = $MI_CLIENT_ID"
+echo "    subject       = $FIC_SUBJECT"
 
-# 5. GitHub Environment + variables + reviewer (prod only)
+# ---------- GitHub side: gh CLI (Bicep cannot model GitHub resources) ----------
 echo "==> GitHub Environment '$ENV'"
 if [[ "$ENV" == "prod" ]]; then
+  # Assumes a user-owned repo. For org-owned repos, look up a team via
+  # `gh api orgs/{org}/teams/{slug}` and use {type:"Team",id:<id>} instead.
   REVIEWER_ID=$(gh api "users/${GH_OWNER}" --jq .id)
   ENV_BODY=$(jq -nc --argjson rid "$REVIEWER_ID" \
     '{wait_timer: 0, prevent_self_review: false, reviewers: [{type: "User", id: $rid}], deployment_branch_policy: null}')
@@ -133,24 +97,12 @@ echo "$ENV_BODY" | gh api -X PUT "repos/${GH_OWNER}/${GH_REPO}/environments/${EN
   --input - --silent
 echo "    upserted environment '$ENV'"
 
-set_env_var() {
-  local name="$1" value="$2"
-  # Use gh variable set (supports --env). Idempotent: replaces existing value.
-  if gh variable set "$name" --env "$ENV" --body "$value" --repo "${GH_OWNER}/${GH_REPO}" >/dev/null 2>&1; then
-    echo "    var $name set"
-  else
-    # Fallback to REST in case the gh CLI version lacks --env support.
-    gh api -X PATCH "repos/${GH_OWNER}/${GH_REPO}/environments/${ENV}/variables/${name}" \
-      -f name="$name" -f value="$value" --silent 2>/dev/null \
-    || gh api -X POST "repos/${GH_OWNER}/${GH_REPO}/environments/${ENV}/variables" \
-      -f name="$name" -f value="$value" --silent
-    echo "    var $name set (via REST)"
-  fi
-}
-set_env_var "AZURE_CLIENT_ID"       "$MI_CLIENT_ID"
-set_env_var "AZURE_SUBSCRIPTION_ID" "$SUB_ID"
+# Env-scoped variables (clientId is public, not a secret).
+gh variable set AZURE_CLIENT_ID       --env "$ENV" --body "$MI_CLIENT_ID"  --repo "${GH_OWNER}/${GH_REPO}"
+gh variable set AZURE_SUBSCRIPTION_ID --env "$ENV" --body "$DEPLOY_SUB_ID" --repo "${GH_OWNER}/${GH_REPO}"
+echo "    set AZURE_CLIENT_ID, AZURE_SUBSCRIPTION_ID for env '$ENV'"
 
-# 6. Repo-level tenant secret (shared across envs; one-time)
+# Repo-level tenant secret (shared across envs; one-time).
 echo "==> Repo secret AZURE_TENANT_ID"
 if gh secret list --repo "${GH_OWNER}/${GH_REPO}" --json name --jq '.[].name' | grep -qx 'AZURE_TENANT_ID'; then
   echo "    already set — leaving as-is"
@@ -164,7 +116,7 @@ cat <<EOF
 ============================================================
 Environment ${ENV} bootstrapped:
   - Resource group:     ${RG_NAME}
-  - GH OIDC identity:   ${MI_NAME} (clientId: ${MI_CLIENT_ID})
+  - GH OIDC clientId:   ${MI_CLIENT_ID}
   - GitHub Environment: https://github.com/${GH_OWNER}/${GH_REPO}/settings/environments
   - Federated subject:  ${FIC_SUBJECT}
 


### PR DESCRIPTION
## What

Splits the previous all-bash `scripts/bootstrap-env.sh` into a declarative Bicep template for the Azure side plus a slim `gh` CLI wrapper for the GitHub side.

## Why this split (researched, not guessed)

Two parallel research passes confirmed this is the canonical Microsoft pattern:

- **Bicep CAN model**: resource group, UAMI, federated identity credential, RG-scoped role assignments. Reference impls: [`Azure/bicep-registry-modules`](https://github.com/Azure/bicep-registry-modules) (`avm/res/managed-identity/user-assigned-identity`), [`Azure/ALZ-Bicep`](https://github.com/Azure/ALZ-Bicep) (deterministic-GUID role-assignment pattern).
- **Bicep CANNOT model**: GitHub Environments, environment variables, repo secrets — those are GitHub API resources outside the Azure ARM surface. Microsoft Learn + GitHub REST API docs both recommend `gh` CLI for this; Terraform's GitHub provider is overkill for one-time Day-0 bootstrap.
- **Chicken-and-egg confirmed real**: the federated credential is the trust anchor; the deploy pipeline can't bootstrap itself. This stays a developer-machine elevated-cred step by design.

## Files

| File | Purpose |
|---|---|
| `infra/bicep/bootstrap.bicep` | Sub-scope orchestrator: declares the RG, then deploys the RG-scoped module |
| `infra/bicep/modules/cd-bootstrap.bicep` | RG-scope: UAMI + federated cred + role assignments |
| `infra/bicep/bootstrap.{dev,ppe,prod}.bicepparam` | Per-env params (uses `readEnvironmentVariable` so the script can override `GH_OWNER`/`GH_REPO`) |
| `scripts/bootstrap-env.sh` | Slimmed wrapper: `az deployment sub create` + `gh` calls (env, vars, secret) |
| `.github/workflows/ci.yml` | `bicep-lint` now also builds `azure.bicep` + `bootstrap.bicep` + 3 new bicepparams |
| `.gitignore` | Adds `.bicep-out/` and `infra/bicep/modules/*.json` |

## Key design decisions

- **API versions** (verified Q4 2024): RG `2024-03-01`, UAMI/FIC `2023-01-31` (stable), role assignments `2022-04-01`.
- **Built-in role IDs hardcoded** in a `var roles = { ... }` map per [Microsoft Learn built-in roles list](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles). Faster than `existing` lookup and bootstrap runs once per env.
- **Deterministic role-assignment GUID** via `guid(resourceGroup().id, mi.id, roleId)` → idempotent re-runs (caveat documented in the module: UAMI delete+recreate also requires deleting old assignments).
- **Federated subject** computed inside Bicep (`repo:${githubOwner}/${githubRepo}:environment:${environmentName}`) and emitted as an output — script just prints it for confirmation.

## Idempotency

- Re-running `./scripts/bootstrap-env.sh ENV=dev` on an already-bootstrapped env: Bicep deployment is a no-op, `gh api -X PUT environments/{env}` upserts, `gh variable set` upserts, secret check skips if present.

## Validation done

- ✅ `az bicep build infra/bicep/bootstrap.bicep` clean
- ✅ `az bicep build-params` clean for all 3 bicepparams
- ✅ `az bicep build infra/bicep/azure.bicep` still clean (now also part of CI)
- ✅ `bash -n scripts/bootstrap-env.sh` + `shellcheck` clean
- ✅ Rubber-duck pass identified two minor doc-only items, both addressed inline.

## Not changed

- `cd.yml` is unaffected — same UAMI clientId / sub / tenant flow as before.
- The chicken-and-egg constraint remains: bootstrap is intentionally a Day-0 elevated-cred step, not a CI job.