### PR TITLE
fix(docker): share NuGet cache across restore→publish with explicit id=nuget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY src/Ftgo.NotificationService/packages.lock.json        src/Ftgo.Notificatio
 COPY src/Ftgo.Auth/packages.lock.json                       src/Ftgo.Auth/
 COPY src/Ftgo.Auth.Client/packages.lock.json                src/Ftgo.Auth.Client/
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
     dotnet restore -a "${TARGETARCH:-amd64}" src/${PROJECT}/${PROJECT}.csproj
 # NOTE: --locked-mode intentionally NOT used here. CI (`ci.yml`) restores the
 # whole solution with --locked-mode on every PR/push, so lock-file integrity
@@ -62,7 +62,12 @@ ARG TARGETARCH
 ARG BUILD_GIT_SHA=local
 ARG BUILD_VERSION=0.0.0-local
 COPY src/ src/
-RUN --mount=type=cache,target=/root/.nuget/packages \
+# Explicit id=nuget on the cache mount ensures BuildKit shares the cache contents
+# with the restore stage above (without an explicit id, BuildKit may scope the
+# mount per-stage, and `dotnet publish --no-restore` then can't find analyzer
+# packages like AsyncFixer → NETSDK1064). Pattern from dotnet/dotnet-docker
+# issue #3353.
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
     dotnet publish src/${PROJECT}/${PROJECT}.csproj \
         -a "${TARGETARCH:-amd64}" \
         --no-restore \


### PR DESCRIPTION
## Problem
Every CD run since the previous green has been failing the `build-images` matrix at the publish stage with:
```
error NETSDK1064: Package AsyncFixer, version 1.6.0 was not found.
```

## Root cause
BuildKit cache mounts without an explicit `id=` are scoped per stage. The publish stage's `--mount=type=cache,target=/root/.nuget/packages` was getting an empty cache instead of the one populated by the restore stage. `dotnet publish --no-restore` then couldn't find any of the analyzer packages registered `PrivateAssets="all"` in `Directory.Build.props` (AsyncFixer, Meziantou.Analyzer, SonarAnalyzer.CSharp, Roslynator.Analyzers).

## Fix
Add matching `id=nuget` to both cache mounts. This is the canonical pattern documented in [dotnet/dotnet-docker#3353](https://github.com/dotnet/dotnet-docker/issues/3353) by the .NET Docker maintainer.

## Diff
```diff
-RUN --mount=type=cache,target=/root/.nuget/packages \\
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \\
     dotnet restore ...

-RUN --mount=type=cache,target=/root/.nuget/packages \\
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \\
     dotnet publish ... --no-restore ...
```

CI on this PR will be the first real validation since I have no local Docker.