### PR TITLE
fix(cd): make end-to-end dev deploy work (Dockerfile cache, RG-scope, RPs, RBAC)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -143,8 +143,8 @@ jobs:
             echo "## dev — Bicep what-if preview"
             echo ""
             echo '```'
-            az deployment sub what-if \
-              --location eastus \
+            az deployment group what-if \
+              --resource-group rg-ftgo-dev-eastus \
               --template-file infra/bicep/azure.bicep \
               --parameters infra/bicep/azure.dev.bicepparam \
               --parameters imageTag="${IMAGE_TAG}" \
@@ -160,15 +160,15 @@ jobs:
         run: |
           set -euo pipefail
           NAME="ftgo-dev-$(date -u +%Y%m%d%H%M%S)"
-          az deployment sub create \
-            --location eastus \
+          az deployment group create \
+            --resource-group rg-ftgo-dev-eastus \
             --template-file infra/bicep/azure.bicep \
             --parameters infra/bicep/azure.dev.bicepparam \
             --parameters imageTag="${IMAGE_TAG}" \
             --name "$NAME" \
             --only-show-errors \
             --output none
-          OUTPUTS=$(az deployment sub show --name "$NAME" --query properties.outputs -o json)
+          OUTPUTS=$(az deployment group show --resource-group rg-ftgo-dev-eastus --name "$NAME" --query properties.outputs -o json)
           AGW_FQDN=$(echo "$OUTPUTS" | jq -r '.apiGatewayFqdn.value')
           SCALAR_URL=$(echo "$OUTPUTS" | jq -r '.scalarUrl.value')
           AGW_REDIRECT=$(echo "$OUTPUTS" | jq -r '.apiGatewayRedirectUri.value')
@@ -237,8 +237,8 @@ jobs:
             echo "## ppe — Bicep what-if preview"
             echo ""
             echo '```'
-            az deployment sub what-if \
-              --location eastus \
+            az deployment group what-if \
+              --resource-group rg-ftgo-ppe-eastus \
               --template-file infra/bicep/azure.bicep \
               --parameters infra/bicep/azure.ppe.bicepparam \
               --parameters imageTag="${IMAGE_TAG}" \
@@ -254,15 +254,15 @@ jobs:
         run: |
           set -euo pipefail
           NAME="ftgo-ppe-$(date -u +%Y%m%d%H%M%S)"
-          az deployment sub create \
-            --location eastus \
+          az deployment group create \
+            --resource-group rg-ftgo-ppe-eastus \
             --template-file infra/bicep/azure.bicep \
             --parameters infra/bicep/azure.ppe.bicepparam \
             --parameters imageTag="${IMAGE_TAG}" \
             --name "$NAME" \
             --only-show-errors \
             --output none
-          OUTPUTS=$(az deployment sub show --name "$NAME" --query properties.outputs -o json)
+          OUTPUTS=$(az deployment group show --resource-group rg-ftgo-ppe-eastus --name "$NAME" --query properties.outputs -o json)
           AGW_FQDN=$(echo "$OUTPUTS" | jq -r '.apiGatewayFqdn.value')
           SCALAR_URL=$(echo "$OUTPUTS" | jq -r '.scalarUrl.value')
           AGW_REDIRECT=$(echo "$OUTPUTS" | jq -r '.apiGatewayRedirectUri.value')
@@ -321,7 +321,7 @@ jobs:
       - name: Preview infra changes (what-if — prod)
         # Prod has a required-reviewer protection rule on the GitHub Environment.
         # The what-if output is rendered to the job summary BEFORE the actual
-        # `az deployment sub create`, so the approver sees the resource diff
+        # `az deployment group create`, so the approver sees the resource diff
         # in the GitHub UI when deciding whether to approve the deploy.
         env:
           IMAGE_TAG: ${{ steps.tag.outputs.imageTag }}
@@ -333,8 +333,8 @@ jobs:
             echo "_Review the resource changes below before approving the deployment._"
             echo ""
             echo '```'
-            az deployment sub what-if \
-              --location eastus \
+            az deployment group what-if \
+              --resource-group rg-ftgo-prod-eastus \
               --template-file infra/bicep/azure.bicep \
               --parameters infra/bicep/azure.prod.bicepparam \
               --parameters imageTag="${IMAGE_TAG}" \
@@ -350,15 +350,15 @@ jobs:
         run: |
           set -euo pipefail
           NAME="ftgo-prod-$(date -u +%Y%m%d%H%M%S)"
-          az deployment sub create \
-            --location eastus \
+          az deployment group create \
+            --resource-group rg-ftgo-prod-eastus \
             --template-file infra/bicep/azure.bicep \
             --parameters infra/bicep/azure.prod.bicepparam \
             --parameters imageTag="${IMAGE_TAG}" \
             --name "$NAME" \
             --only-show-errors \
             --output none
-          OUTPUTS=$(az deployment sub show --name "$NAME" --query properties.outputs -o json)
+          OUTPUTS=$(az deployment group show --resource-group rg-ftgo-prod-eastus --name "$NAME" --query properties.outputs -o json)
           AGW_FQDN=$(echo "$OUTPUTS" | jq -r '.apiGatewayFqdn.value')
           SCALAR_URL=$(echo "$OUTPUTS" | jq -r '.scalarUrl.value')
           AGW_REDIRECT=$(echo "$OUTPUTS" | jq -r '.apiGatewayRedirectUri.value')

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,14 +46,21 @@ COPY src/Ftgo.NotificationService/packages.lock.json        src/Ftgo.Notificatio
 COPY src/Ftgo.Auth/packages.lock.json                       src/Ftgo.Auth/
 COPY src/Ftgo.Auth.Client/packages.lock.json                src/Ftgo.Auth.Client/
 
-RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
-    dotnet restore -a "${TARGETARCH:-amd64}" src/${PROJECT}/${PROJECT}.csproj
-# NOTE: --locked-mode intentionally NOT used here. CI (`ci.yml`) restores the
+RUN dotnet restore -a "${TARGETARCH:-amd64}" src/${PROJECT}/${PROJECT}.csproj
+# NOTE 1: --locked-mode intentionally NOT used here. CI (`ci.yml`) restores the
 # whole solution with --locked-mode on every PR/push, so lock-file integrity
 # is already enforced before any image is built. Adding it here would conflict
 # with the per-RID restore (lock files don't include runtime identifiers, so
 # `-a $TARGETARCH` produces an RID set the lock file never recorded → NU1004).
-# Matches dotnet/dotnet-docker official samples.
+# NOTE 2: No `--mount=type=cache` for /root/.nuget/packages. With GHA layer
+# cache (cache-from/to=type=gha), a layer-cache HIT on this RUN means BuildKit
+# doesn't execute it, so a host-side cache mount never gets populated for that
+# build. The publish stage's `--no-restore` would then fail with NETSDK1064
+# (analyzer packages like AsyncFixer / Meziantou with PrivateAssets="all" are
+# resolved at publish time from /root/.nuget/packages). Letting packages live
+# in the image layer (canonical dotnet/dotnet-docker samples pattern) means
+# they flow naturally to the publish stage via `FROM restore AS publish` and
+# are persisted across CI runs by GHA layer cache itself.
 
 # ─── Stage 2: publish ───
 FROM restore AS publish
@@ -62,13 +69,7 @@ ARG TARGETARCH
 ARG BUILD_GIT_SHA=local
 ARG BUILD_VERSION=0.0.0-local
 COPY src/ src/
-# Explicit id=nuget on the cache mount ensures BuildKit shares the cache contents
-# with the restore stage above (without an explicit id, BuildKit may scope the
-# mount per-stage, and `dotnet publish --no-restore` then can't find analyzer
-# packages like AsyncFixer → NETSDK1064). Pattern from dotnet/dotnet-docker
-# issue #3353.
-RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
-    dotnet publish src/${PROJECT}/${PROJECT}.csproj \
+RUN dotnet publish src/${PROJECT}/${PROJECT}.csproj \
         -a "${TARGETARCH:-amd64}" \
         --no-restore \
         -c Release \

--- a/infra/bicep/azure.bicep
+++ b/infra/bicep/azure.bicep
@@ -1,9 +1,9 @@
 metadata name = 'azure-orchestrator'
-metadata description = 'Subscription-scope orchestrator that creates rg-ftgo-{env}-{location} and deploys Log Analytics, App Insights, Key Vault, the Container Apps managed environment, the 7 FTGO container apps, and Key Vault RBAC for their managed identities.'
+metadata description = 'Resource-group-scope orchestrator that deploys Log Analytics, App Insights, Key Vault, the Container Apps managed environment, the 7 FTGO container apps, and Key Vault RBAC for their managed identities. The target resource group is created beforehand by infra/bicep/bootstrap.bicep, so the CD UAMI only needs RG-scope Contributor (least privilege).'
 
 extension az
 
-targetScope = 'subscription'
+targetScope = 'resourceGroup'
 
 @description('Logical environment name; controls resource-group, naming, and ASPNETCORE_ENVIRONMENT.')
 @allowed([ 'dev', 'ppe', 'prod' ])
@@ -36,22 +36,14 @@ var regionShortMap = {
 }
 var regionShort = regionShortMap[?location] ?? toLower(take(location, 3))
 
-var rgName       = 'rg-ftgo-${environmentName}-${location}'
 var lawName      = 'ftgo-${environmentName}-law-${regionShort}'
 var aiName       = 'ftgo-${environmentName}-ai-${regionShort}'
 var caeName      = 'ftgo-${environmentName}-cae-${regionShort}'
 // KV global uniqueness: 'kv-ftgo-{env}-{8-char hash of rg.id}' = max 21 chars (within the 24 limit).
-var kvName       = 'kv-ftgo-${environmentName}-${take(uniqueString(subscription().subscriptionId, rgName), 8)}'
-
-resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
-  name:     rgName
-  location: location
-  tags:     tags
-}
+var kvName       = 'kv-ftgo-${environmentName}-${take(uniqueString(resourceGroup().id), 8)}'
 
 module logAnalytics 'modules/log-analytics.bicep' = {
   name:  'law'
-  scope: resourceGroup(rg.name)
   params: {
     name:     lawName
     location: location
@@ -61,7 +53,6 @@ module logAnalytics 'modules/log-analytics.bicep' = {
 
 module appInsights 'modules/app-insights.bicep' = {
   name:  'ai'
-  scope: resourceGroup(rg.name)
   params: {
     name:                aiName
     location:            location
@@ -72,7 +63,6 @@ module appInsights 'modules/app-insights.bicep' = {
 
 module keyVault 'modules/key-vault.bicep' = {
   name:  'kv'
-  scope: resourceGroup(rg.name)
   params: {
     name:     kvName
     location: location
@@ -83,7 +73,6 @@ module keyVault 'modules/key-vault.bicep' = {
 
 module containerAppsEnv 'modules/container-apps-environment.bicep' = {
   name:  'cae'
-  scope: resourceGroup(rg.name)
   params: {
     name:                    caeName
     location:                location
@@ -95,7 +84,6 @@ module containerAppsEnv 'modules/container-apps-environment.bicep' = {
 
 module acaStack 'modules/aca-stack.bicep' = {
   name:  'aca-stack'
-  scope: resourceGroup(rg.name)
   params: {
     environmentName:             environmentName
     location:                    location
@@ -110,7 +98,6 @@ module acaStack 'modules/aca-stack.bicep' = {
 
 module kvRbac 'modules/key-vault-rbac.bicep' = {
   name:  'kv-rbac'
-  scope: resourceGroup(rg.name)
   params: {
     keyVaultName: keyVault.outputs.keyVaultName
     principalIds: acaStack.outputs.principalIds
@@ -118,7 +105,7 @@ module kvRbac 'modules/key-vault-rbac.bicep' = {
 }
 
 @description('Resource group containing every FTGO resource for this environment.')
-output resourceGroupName string = rg.name
+output resourceGroupName string = resourceGroup().name
 
 @description('Log Analytics workspace resource ID.')
 output logAnalyticsWorkspaceId string = logAnalytics.outputs.workspaceId

--- a/infra/bicep/bootstrap.bicep
+++ b/infra/bicep/bootstrap.bicep
@@ -31,11 +31,11 @@ var roles = {
   UserAccessAdministrator: '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
 }
 
-// Prod also needs User Access Administrator so the deploy pipeline can grant
-// Key Vault RBAC to the per-app managed identities created by azure.bicep.
-var roleIds = environmentName == 'prod'
-  ? [ roles.Contributor, roles.UserAccessAdministrator ]
-  : [ roles.Contributor ]
+// All envs need User Access Administrator (RG-scoped) so the deploy pipeline
+// can grant Key Vault RBAC to the per-app managed identities created by
+// azure.bicep (modules/key-vault-rbac.bicep). The role is scoped to this RG
+// only — the UAMI cannot assign roles outside its environment.
+var roleIds = [ roles.Contributor, roles.UserAccessAdministrator ]
 
 var tags = {
   environment: environmentName

--- a/scripts/bootstrap-env.sh
+++ b/scripts/bootstrap-env.sh
@@ -80,6 +80,24 @@ echo "==> tenant       : ${TENANT_ID}"
 echo "==> env          : ${ENV}"
 echo
 
+# ---------- Resource provider registration (one-time per subscription, idempotent) ----------
+# New Azure subscriptions don't auto-register every RP; first deploy that touches an
+# unregistered namespace fails with MissingSubscriptionRegistration. Registration is
+# sub-scoped + asynchronous; we kick off all required RPs in parallel and don't wait
+# (registration completes within seconds, well before bootstrap.bicep runs).
+RPS=(
+  Microsoft.KeyVault
+  Microsoft.OperationalInsights   # Log Analytics
+  Microsoft.Insights              # App Insights
+  Microsoft.App                   # Container Apps
+  Microsoft.ManagedIdentity       # UAMI (usually pre-registered, but harmless)
+)
+echo "==> Registering resource providers (idempotent): ${RPS[*]}"
+for rp in "${RPS[@]}"; do
+  az provider register --namespace "$rp" --only-show-errors --output none &
+done
+wait
+
 # ---------- Azure side: infra/bicep/bootstrap.bicep ----------
 DEPLOY_NAME="bootstrap-${ENV}-$(date +%Y%m%d%H%M%S)"
 echo "==> Deploying infra/bicep/bootstrap.bicep ($DEPLOY_NAME)"


### PR DESCRIPTION
End-to-end CD pipeline now works. Validated via `workflow_dispatch` on this branch — all 7 build-images + deploy-dev are green ([run](https://github.com/mghabin/entra-auth-patterns-dotnet/actions/runs/24938372138)).

Four fixes layered together (each was the next blocker after the previous):

### 1. Dockerfile — drop NuGet cache mounts (canonical Microsoft samples pattern)
PR #24's `id=nuget` cache-mount fix worked when validated on a clean branch but broke once GHA layer cache became hot on main. BuildKit only binds `--mount=type=cache` when the RUN actually executes; on a layer-cache HIT the mount stays empty for that build, then `dotnet publish --no-restore` fails with NETSDK1064 (analyzers with `PrivateAssets="all"` resolved at publish time can't be found).

**Fix:** drop cache mounts entirely; let packages live in the image layer. Packages flow naturally from `restore` stage to `publish` stage via `FROM restore AS publish`, and GHA layer cache preserves them across runs (which cache mounts cannot). Matches `dotnet/dotnet-docker` official samples.

### 2. azure.bicep — RG-scope deployment (least-privilege)
`bootstrap.bicep` already creates `rg-ftgo-{env}-{location}` and grants the CD UAMI Contributor at RG scope. `azure.bicep` was redundantly re-declaring the RG and deploying at sub scope, which required Contributor at sub scope to validate — broader than necessary, mismatched with what bootstrap actually granted (AuthorizationFailed on `Microsoft.Resources/deployments/validate/action` at sub scope).

- `azure.bicep`: `targetScope` sub → resourceGroup; drop the `rg` resource; drop `scope: resourceGroup(rg.name)` from each module; replace `subscription().subscriptionId` / `rg.name` references with `resourceGroup()` helpers.
- `cd.yml`: `az deployment sub create/what-if/show` → `az deployment group …` with `--resource-group rg-ftgo-{env}-eastus`, in all 3 envs.

Federated credential and RBAC are unchanged — FIC subject is GitHub-side (`repo:OWNER/REPO:environment:ENV`), and the role assignment was already RG-scoped — it just didn't match the deployment scope until now.

### 3. bootstrap-env.sh — register required Azure resource providers
New Azure subs don't auto-register every RP namespace. First deploy that touches an unregistered RP fails with `MissingSubscriptionRegistration`. Registration is sub-scope + idempotent + async; bootstrap-env.sh runs as the human Owner and already touches sub-scope, so this is the natural place. Registers `KeyVault`, `OperationalInsights`, `Insights`, `App`, `ManagedIdentity` in parallel.

### 4. bootstrap.bicep — grant User Access Administrator to all envs
`azure.bicep`'s `kv-rbac` module assigns `Key Vault Secrets User` to each app's managed identity — requires `Microsoft.Authorization/roleAssignments/write`, which Contributor lacks. Previously only prod had UserAccessAdministrator; dev/ppe deploys failed at the kv-rbac step. Role is still RG-scoped — blast radius contained per environment.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>