### PR TITLE
refactor(entra): rename local app regs ftgo-* → ftgo-local-* for env consistency

### DIFF
--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -55,7 +55,7 @@ dotnet run --project src/Ftgo.ApiGateway        # https://localhost:7101
 ```
 
 Acquire a user token (e.g. Postman → Authorization Code with PKCE
-against the `ftgo-apigateway` app reg, with redirect
+against the `ftgo-local-apigateway` app reg, with redirect
 `https://localhost:7101/signin-oidc`) and exercise:
 
 ```bash

--- a/docs/sample-setup.md
+++ b/docs/sample-setup.md
@@ -25,13 +25,13 @@ auth shapes are taught against recognisable, business-meaningful names.
 
 Create seven app registrations. Provisioning is declarative via the **Microsoft.Graph Bicep extension** at `infra/bicep/main.bicep`, run through `scripts/deploy.sh` — apps, service principals, scopes/roles and admin-consented permissions are created idempotently:
 
-1. **ftgo-apigateway** (single-tenant) — consumes the `orders.read` delegated scope on behalf of users.
-2. **ftgo-orderservice** (single-tenant) — exposes scope `orders.read` and app role `Orders.Process`.
-3. **ftgo-restaurantservice** (multi-tenant, `signInAudience: AzureADMultipleOrgs`) — exposes app role `Restaurants.Read.All`.
-4. **ftgo-kitchenservice** (single-tenant, optional) — only needed if running outside Azure; in Azure the identity is a **Managed Identity**.
-5. **ftgo-accountingservice** (single-tenant) — has a **certificate** credential whose private key lives in Key Vault.
-6. **ftgo-deliveryservice** (single-tenant) — has a **federated identity credential** (GitHub Actions / AKS / etc.).
-7. **ftgo-notificationservice** (single-tenant) — has a **client secret** (anti-pattern; rotate ≤ 6 months).
+1. **ftgo-local-apigateway** (single-tenant) — consumes the `orders.read` delegated scope on behalf of users.
+2. **ftgo-local-orderservice** (single-tenant) — exposes scope `orders.read` and app role `Orders.Process`.
+3. **ftgo-local-restaurantservice** (multi-tenant, `signInAudience: AzureADMultipleOrgs`) — exposes app role `Restaurants.Read.All`.
+4. **ftgo-local-kitchenservice** (single-tenant, optional) — only needed if running outside Azure; in Azure the identity is a **Managed Identity**.
+5. **ftgo-local-accountingservice** (single-tenant) — has a **certificate** credential whose private key lives in Key Vault.
+6. **ftgo-local-deliveryservice** (single-tenant) — has a **federated identity credential** (GitHub Actions / AKS / etc.).
+7. **ftgo-local-notificationservice** (single-tenant) — has a **client secret** (anti-pattern; rotate ≤ 6 months).
 
 For each API app reg, set manifest `requestedAccessTokenVersion = 2` so
 `aud` is the API's client ID GUID.
@@ -40,13 +40,13 @@ For each API app reg, set manifest `requestedAccessTokenVersion = 2` so
 
 | Caller                                | Callee                  | Permission                                                          |
 |---------------------------------------|-------------------------|---------------------------------------------------------------------|
-| ftgo-apigateway (delegated)           | ftgo-orderservice       | scope `orders.read` (admin-consented)                               |
-| ftgo-apigateway (app)                 | ftgo-orderservice       | role `Orders.Process`                                               |
-| ftgo-apigateway (app)                 | ftgo-restaurantservice  | role `Restaurants.Read.All` (consented in each provisioned tenant)  |
-| ftgo-kitchenservice MI                | ftgo-orderservice       | role `Orders.Process` (assign with `New-MgServicePrincipalAppRoleAssignment`) |
-| ftgo-accountingservice                | ftgo-orderservice       | role `Orders.Process`                                               |
-| ftgo-deliveryservice                  | ftgo-restaurantservice  | role `Restaurants.Read.All`                                         |
-| ftgo-notificationservice              | ftgo-orderservice       | role `Orders.Process`                                               |
+| ftgo-local-apigateway (delegated)           | ftgo-local-orderservice       | scope `orders.read` (admin-consented)                               |
+| ftgo-local-apigateway (app)                 | ftgo-local-orderservice       | role `Orders.Process`                                               |
+| ftgo-local-apigateway (app)                 | ftgo-local-restaurantservice  | role `Restaurants.Read.All` (consented in each provisioned tenant)  |
+| ftgo-local-kitchenservice MI                | ftgo-local-orderservice       | role `Orders.Process` (assign with `New-MgServicePrincipalAppRoleAssignment`) |
+| ftgo-local-accountingservice                | ftgo-local-orderservice       | role `Orders.Process`                                               |
+| ftgo-local-deliveryservice                  | ftgo-local-restaurantservice  | role `Restaurants.Read.All`                                         |
+| ftgo-local-notificationservice              | ftgo-local-orderservice       | role `Orders.Process`                                               |
 
 Set `appRoleAssignmentRequired = true` on the resource APIs so only
 allow-listed callers receive `roles`.

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -16,7 +16,7 @@ param tenantId string
 @maxLength(16)
 param prefix string = 'ftgo'
 
-@description('Logical environment name. "local" keeps the existing local-dev names (ftgo-*); cloud envs (dev/ppe/prod) suffix it (ftgo-dev-*).')
+@description('Logical environment name. Always suffixed onto the prefix (ftgo-local-*, ftgo-dev-*, …) so each env owns an isolated set of app regs.')
 @allowed([ 'local', 'dev', 'ppe', 'prod' ])
 param environmentName string = 'local'
 
@@ -26,7 +26,7 @@ param apiGatewayRedirectUri string = 'https://localhost:7101/signin-oidc'
 @description('SPA redirect URI for Scalar PKCE callback on the BFF.')
 param scalarRedirectUri string = 'https://localhost:7101/scalar/v1'
 
-var effectivePrefix = environmentName == 'local' ? prefix : '${prefix}-${environmentName}'
+var effectivePrefix = '${prefix}-${environmentName}'
 
 module appRegistrations 'modules/app-registrations.bicep' = {
   name: 'app-registrations'

--- a/infra/bicep/main.bicepparam
+++ b/infra/bicep/main.bicepparam
@@ -12,5 +12,6 @@ using 'main.bicep'
 
 param tenantId             = readEnvironmentVariable('AZURE_TENANT_ID')
 param prefix               = readEnvironmentVariable('FTGO_PREFIX',                'ftgo')
+param environmentName      = 'local'
 param apiGatewayRedirectUri = readEnvironmentVariable('FTGO_GATEWAY_REDIRECT_URI', 'https://localhost:7101/signin-oidc')
 param scalarRedirectUri     = readEnvironmentVariable('FTGO_SCALAR_REDIRECT_URI',  'https://localhost:7101/scalar/v1')

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -136,16 +136,16 @@ fi
 
 echo
 echo "==> Self-signed cert for AccountingService"
-APP_NAME=ftgo-accountingservice "$HERE/new-cert.sh"
-ACCT_PFX="$ROOT/.certs/ftgo-accountingservice.pfx"
+APP_NAME=ftgo-local-accountingservice "$HERE/new-cert.sh"
+ACCT_PFX="$ROOT/.certs/ftgo-local-accountingservice.pfx"
 
 # ApiGateway also needs a credential for downstream OBO. In Azure it uses a federated assertion via
 # managed identity (`SignedAssertionFromManagedIdentity`); on a laptop there's no IMDS, so we generate
 # a local cert and override `AzureAd:ClientCredentials` via user-secrets to source from disk.
 echo
 echo "==> Self-signed cert for ApiGateway (local-dev OBO)"
-APP_NAME=ftgo-apigateway "$HERE/new-cert.sh"
-GATE_PFX="$ROOT/.certs/ftgo-apigateway.pfx"
+APP_NAME=ftgo-local-apigateway "$HERE/new-cert.sh"
+GATE_PFX="$ROOT/.certs/ftgo-local-apigateway.pfx"
 
 echo
 echo "==> Hydrating dotnet user-secrets for 7 projects"

--- a/scripts/new-cert.sh
+++ b/scripts/new-cert.sh
@@ -2,13 +2,13 @@
 # scripts/new-cert.sh — generate a self-signed cert for an app registration and upload the
 # public key. Idempotent. The .pfx stays local; do NOT commit it.
 #
-# Usage:  APP_NAME=ftgo-apigateway ./scripts/new-cert.sh
+# Usage:  APP_NAME=ftgo-local-apigateway ./scripts/new-cert.sh
 #
 # Prereqs: openssl, az CLI logged in.
 
 set -euo pipefail
 
-APP_NAME="${APP_NAME:-ftgo-accountingservice}"
+APP_NAME="${APP_NAME:-ftgo-local-accountingservice}"
 OUT_DIR="${OUT_DIR:-./.certs}"
 SUBJECT="${SUBJECT:-/CN=${APP_NAME}}"
 DAYS="${DAYS:-365}"

--- a/src/Ftgo.AccountingService/appsettings.json
+++ b/src/Ftgo.AccountingService/appsettings.json
@@ -5,7 +5,7 @@
   },
   "KeyVault": {
     "Uri":      "https://example-kv.vault.azure.net/",
-    "CertName": "ftgo-accountingservice"
+    "CertName": "ftgo-local-accountingservice"
   },
   "Downstream": {
     "BaseUrl": "https://localhost:7102/",


### PR DESCRIPTION
Drops the `environmentName == 'local'` special-case so every env follows the same `${prefix}-${env}-${svc}` naming. Local now matches dev/ppe/prod (per Microsoft Identity Platform best practice: per-env isolated app regs, no shared blast radius).

## Changes
- `infra/bicep/main.bicep` — drop ternary, always `${prefix}-${environmentName}`
- `infra/bicep/main.bicepparam` — pin `environmentName='local'` explicitly  
- `infra/bicep/main.json` — regenerated
- `scripts/deploy.sh`, `scripts/new-cert.sh` — cert paths now `ftgo-local-*`
- `src/Ftgo.AccountingService/appsettings.json` — `KeyVault.CertName` → `ftgo-local-accountingservice`
- `docs/run-locally.md`, `docs/sample-setup.md` — display-name updates

## Tenant state
The 7 old `ftgo-*` app regs were deleted (uniqueName is immutable in Graph, so in-place rename wasn't possible). Re-running `./scripts/deploy.sh` recreates them as `ftgo-local-*` (idempotent — mints fresh certs + hydrates user-secrets).

Cloud envs (`ftgo-dev-*`) are unaffected.