### PR TITLE
feat(observability): split health probes into /health/live and /health/ready

### DIFF
--- a/infra/bicep/modules/aca-stack.bicep
+++ b/infra/bicep/modules/aca-stack.bicep
@@ -25,7 +25,7 @@ param regionShort string
 @description('Tags applied to every container app.')
 param tags object = {}
 
-@description('Service definitions. project = csproj folder name; shortName = lowercase image/name suffix (also used as the Bicep map key); isWebApp = whether to expose HTTP ingress + /health probe.')
+@description('Service definitions. project = csproj folder name; shortName = lowercase image/name suffix (also used as the Bicep map key); isWebApp = whether to expose HTTP ingress + /health/live + /health/ready probes.')
 param services array = [
   { project: 'Ftgo.ApiGateway',      shortName: 'apigateway',       isWebApp: true  }
   { project: 'Ftgo.Orders.Api',      shortName: 'orders-api',       isWebApp: true  }

--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -1,5 +1,5 @@
 metadata name = 'container-app'
-metadata description = 'Single Azure Container App (Consumption) with system-assigned MI, external HTTP ingress on 8080, /health liveness probe, and 0–3 HTTP-concurrency scaling.'
+metadata description = 'Single Azure Container App (Consumption) with system-assigned MI, external HTTP ingress on 8080, /health/live + /health/ready probes, and 0–3 HTTP-concurrency scaling.'
 
 extension az
 
@@ -91,13 +91,25 @@ resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
             {
               type: 'Liveness'
               httpGet: {
-                path: '/health'
+                path: '/health/live'
                 port: 8080
                 scheme: 'HTTP'
               }
               initialDelaySeconds: 10
               periodSeconds:       30
               timeoutSeconds:      5
+              failureThreshold:    3
+            }
+            {
+              type: 'Readiness'
+              httpGet: {
+                path: '/health/ready'
+                port: 8080
+                scheme: 'HTTP'
+              }
+              initialDelaySeconds: 5
+              periodSeconds:       10
+              timeoutSeconds:      3
               failureThreshold:    3
             }
           ] : []

--- a/src/Ftgo.ApiGateway/Program.cs
+++ b/src/Ftgo.ApiGateway/Program.cs
@@ -24,5 +24,5 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
 app.MapEntraAuthScalar(builder.Configuration, "orders.read");
-app.MapHealthChecks("/health");
+app.MapEntraAuthHealthChecks();
 await app.RunAsync();

--- a/src/Ftgo.Auth/HealthChecksExtensions.cs
+++ b/src/Ftgo.Auth/HealthChecksExtensions.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Ftgo.Auth;
+
+/// <summary>Split health probes following the ASP.NET Core / Kubernetes convention:
+/// <list type="bullet">
+///   <item><c>/health/live</c> — the process is alive (no external dependency checks). Used by liveness probes; failure means restart the pod.</item>
+///   <item><c>/health/ready</c> — the process can serve traffic (all "ready" tag checks pass). Used by readiness probes; failure means stop sending traffic but don't restart.</item>
+/// </list>
+/// <para>Tag checks registered with <c>AddCheck&lt;T&gt;("name", tags: ["ready"])</c> participate in <c>/health/ready</c>.
+/// Tag-less checks participate in liveness only.</para>
+/// </summary>
+public static class HealthChecksExtensions
+{
+    /// <summary>Maps <c>/health/live</c> (always-200 once the process started) and <c>/health/ready</c>
+    /// (200 only when all checks tagged <c>ready</c> pass). Container Apps / K8s probes should hit these
+    /// instead of a single combined <c>/health</c>.</summary>
+    public static IEndpointRouteBuilder MapEntraAuthHealthChecks(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        endpoints.MapHealthChecks("/health/live", new HealthCheckOptions
+        {
+            Predicate = static _ => false,
+        });
+
+        endpoints.MapHealthChecks("/health/ready", new HealthCheckOptions
+        {
+            Predicate = static check => check.Tags.Contains("ready"),
+        });
+
+        return endpoints;
+    }
+}

--- a/src/Ftgo.Orders.Api/Program.cs
+++ b/src/Ftgo.Orders.Api/Program.cs
@@ -16,5 +16,5 @@ app.UseAuthorization();
 app.MapControllers();
 app.MapOpenApi();
 app.MapScalarApiReference();
-app.MapHealthChecks("/health");
+app.MapEntraAuthHealthChecks();
 await app.RunAsync();

--- a/src/Ftgo.Restaurants.Api/Program.cs
+++ b/src/Ftgo.Restaurants.Api/Program.cs
@@ -16,5 +16,5 @@ app.UseAuthorization();
 app.MapControllers();
 app.MapOpenApi();
 app.MapScalarApiReference();
-app.MapHealthChecks("/health");
+app.MapEntraAuthHealthChecks();
 await app.RunAsync();

--- a/tests/Ftgo.Auth.Tests/HealthChecksExtensionsTests.cs
+++ b/tests/Ftgo.Auth.Tests/HealthChecksExtensionsTests.cs
@@ -1,0 +1,71 @@
+using Ftgo.Auth;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Ftgo.Auth.Tests;
+
+public sealed class HealthChecksExtensionsTests
+{
+    [Fact]
+    public async Task Live_endpoint_returns_200_when_only_dep_check_is_unhealthy()
+    {
+        using var host = await BuildHostAsync(includeUnhealthyReadyCheck: true);
+        using var client = host.GetTestClient();
+
+        var response = await client.GetAsync(new Uri("/health/live", UriKind.Relative), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Ready_endpoint_returns_503_when_a_ready_check_is_unhealthy()
+    {
+        using var host = await BuildHostAsync(includeUnhealthyReadyCheck: true);
+        using var client = host.GetTestClient();
+
+        var response = await client.GetAsync(new Uri("/health/ready", UriKind.Relative), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task Ready_endpoint_returns_200_when_no_ready_checks_are_registered()
+    {
+        using var host = await BuildHostAsync(includeUnhealthyReadyCheck: false);
+        using var client = host.GetTestClient();
+
+        var response = await client.GetAsync(new Uri("/health/ready", UriKind.Relative), TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+    }
+
+    private static async Task<IHost> BuildHostAsync(bool includeUnhealthyReadyCheck)
+    {
+        var builder = new HostBuilder().ConfigureWebHost(web =>
+        {
+            web.UseTestServer();
+            web.ConfigureServices(services =>
+            {
+                services.AddRouting();
+                var hc = services.AddHealthChecks();
+                if (includeUnhealthyReadyCheck)
+                {
+                    hc.AddCheck("downstream-db", () => HealthCheckResult.Unhealthy(), tags: ["ready"]);
+                }
+            });
+            web.Configure(app =>
+            {
+                app.UseRouting();
+                app.UseEndpoints(e => e.MapEntraAuthHealthChecks());
+            });
+        });
+        var host = await builder.StartAsync(TestContext.Current.CancellationToken);
+        return host;
+    }
+}


### PR DESCRIPTION
## Why

ASP.NET Core / Kubernetes / Container Apps best practice is to have **two
distinct** health probes:

- **Liveness** (`/health/live`) — am I alive? **Must not** depend on
  external systems. A down database should not cause the platform to
  restart the pod (it'll just keep crash-looping). Failure ⇒ restart.
- **Readiness** (`/health/ready`) — am I ready to serve traffic? *May*
  depend on external systems. Failure ⇒ stop sending traffic, but don't
  restart.

The repo previously had a single `/health` endpoint mapped as a Liveness
probe, which conflates the two and breaks the pattern.

## What changed

- **`src/Ftgo.Auth/HealthChecksExtensions.cs`** (new) — `MapEntraAuthHealthChecks()` helper:
  - `/health/live` always returns 200 once the process is up (predicate `_ => false`, no checks).
  - `/health/ready` runs only checks tagged `ready` (predicate `c => c.Tags.Contains("ready")`).
  - Future readiness checks plug in with `services.AddHealthChecks().AddCheck<DbCheck>("db", tags: ["ready"])`.
- **`ApiGateway` / `Orders.Api` / `Restaurants.Api`** `Program.cs` — replace single `MapHealthChecks("/health")` with `MapEntraAuthHealthChecks()`.
- **`infra/bicep/modules/container-app.bicep`** — Container Apps probes:
  - `Liveness`: `/health/live`, 30s period, 3 failure threshold.
  - `Readiness`: `/health/ready`, 10s period (faster recovery on transient deps).
- **`tests/Ftgo.Auth.Tests/HealthChecksExtensionsTests.cs`** — 3 tests pin the live/ready semantics:
  1. `/health/live` returns 200 even when a `ready`-tagged check is unhealthy.
  2. `/health/ready` returns 503 when a `ready`-tagged check is unhealthy.
  3. `/health/ready` returns 200 when no `ready` checks are registered.

## Verification

- `dotnet build / test / format --verify-no-changes` — green (27/27 tests).
- `az bicep build` — clean.

## Reference

Aligns with `mghabin/dotnet-engineering-guide` cloud-native health-check
guidance.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
