### PR TITLE
fix(deploy): eliminate env-var drift via declarative entraConfig wiring

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -140,9 +140,33 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Resolve entraConfig
+        id: entra
+        env:
+          ENTRA_CONFIG_JSON: ${{ vars.ENTRA_CONFIG_JSON }}
+        run: |
+          set -euo pipefail
+          # ENTRA_CONFIG_JSON is written as a GitHub env-level variable by
+          # `scripts/provision-apps.sh ENV=dev` (manual, one-time per env or when app
+          # regs change). Falls back to `{}` for cold envs where provisioning hasn't
+          # happened yet — the deploy still succeeds, apps come up with appsettings
+          # placeholders, and the operator runs provision-apps.sh once to populate.
+          if [ -z "${ENTRA_CONFIG_JSON}" ]; then
+            echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
+            echo '⚠ ENTRA_CONFIG_JSON unset for env=dev — deploying with empty entraConfig (apps will use appsettings placeholders).' >> "$GITHUB_STEP_SUMMARY"
+          else
+            # Use a heredoc-safe delimiter so multiline JSON survives intact.
+            {
+              echo "entraConfig<<__EOF__"
+              echo "$ENTRA_CONFIG_JSON"
+              echo "__EOF__"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Preview infra changes (what-if — dev)
         env:
           IMAGE_TAG: ${{ steps.tag.outputs.imageTag }}
+          ENTRA_CONFIG: ${{ steps.entra.outputs.entraConfig }}
         run: |
           set -euo pipefail
           {
@@ -153,7 +177,7 @@ jobs:
               --resource-group rg-ftgo-dev-eastus \
               --template-file infra/bicep/azure.bicep \
               --parameters infra/bicep/azure.dev.bicepparam \
-              --parameters imageTag="${IMAGE_TAG}" \
+              --parameters imageTag="${IMAGE_TAG}" entraConfig="${ENTRA_CONFIG}" \
               --result-format FullResourcePayloads \
               --no-pretty-print 2>&1 | tail -200 || true
             echo '```'
@@ -163,6 +187,7 @@ jobs:
         id: deploy
         env:
           IMAGE_TAG: ${{ steps.tag.outputs.imageTag }}
+          ENTRA_CONFIG: ${{ steps.entra.outputs.entraConfig }}
         run: |
           set -euo pipefail
           NAME="ftgo-dev-$(date -u +%Y%m%d%H%M%S)"
@@ -170,7 +195,7 @@ jobs:
             --resource-group rg-ftgo-dev-eastus \
             --template-file infra/bicep/azure.bicep \
             --parameters infra/bicep/azure.dev.bicepparam \
-            --parameters imageTag="${IMAGE_TAG}" \
+            --parameters imageTag="${IMAGE_TAG}" entraConfig="${ENTRA_CONFIG}" \
             --name "$NAME" \
             --only-show-errors \
             --output none
@@ -192,7 +217,7 @@ jobs:
             echo "- Scalar: ${{ steps.deploy.outputs.scalar_url }}"
             echo "- BFF: https://${{ steps.deploy.outputs.apigateway_fqdn }}"
             echo ""
-            echo "_Entra app regs are provisioned out-of-band via_ \`scripts/provision-apps.sh ENV=dev\`."
+            echo "_Entra app regs are provisioned out-of-band via_ \`scripts/provision-apps.sh ENV=dev\`_, which writes the_ \`ENTRA_CONFIG_JSON\` _GitHub env var consumed here._"
           } >> "$GITHUB_STEP_SUMMARY"
 
   deploy-ppe:
@@ -234,9 +259,27 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Resolve entraConfig
+        id: entra
+        env:
+          ENTRA_CONFIG_JSON: ${{ vars.ENTRA_CONFIG_JSON }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ENTRA_CONFIG_JSON}" ]; then
+            echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
+            echo '⚠ ENTRA_CONFIG_JSON unset for env=ppe — deploying with empty entraConfig (apps will use appsettings placeholders).' >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "entraConfig<<__EOF__"
+              echo "$ENTRA_CONFIG_JSON"
+              echo "__EOF__"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Preview infra changes (what-if — ppe)
         env:
           IMAGE_TAG: ${{ steps.tag.outputs.imageTag }}
+          ENTRA_CONFIG: ${{ steps.entra.outputs.entraConfig }}
         run: |
           set -euo pipefail
           {
@@ -247,7 +290,7 @@ jobs:
               --resource-group rg-ftgo-ppe-eastus \
               --template-file infra/bicep/azure.bicep \
               --parameters infra/bicep/azure.ppe.bicepparam \
-              --parameters imageTag="${IMAGE_TAG}" \
+              --parameters imageTag="${IMAGE_TAG}" entraConfig="${ENTRA_CONFIG}" \
               --result-format FullResourcePayloads \
               --no-pretty-print 2>&1 | tail -200 || true
             echo '```'
@@ -257,6 +300,7 @@ jobs:
         id: deploy
         env:
           IMAGE_TAG: ${{ steps.tag.outputs.imageTag }}
+          ENTRA_CONFIG: ${{ steps.entra.outputs.entraConfig }}
         run: |
           set -euo pipefail
           NAME="ftgo-ppe-$(date -u +%Y%m%d%H%M%S)"
@@ -264,7 +308,7 @@ jobs:
             --resource-group rg-ftgo-ppe-eastus \
             --template-file infra/bicep/azure.bicep \
             --parameters infra/bicep/azure.ppe.bicepparam \
-            --parameters imageTag="${IMAGE_TAG}" \
+            --parameters imageTag="${IMAGE_TAG}" entraConfig="${ENTRA_CONFIG}" \
             --name "$NAME" \
             --only-show-errors \
             --output none
@@ -325,6 +369,23 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Resolve entraConfig
+        id: entra
+        env:
+          ENTRA_CONFIG_JSON: ${{ vars.ENTRA_CONFIG_JSON }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ENTRA_CONFIG_JSON}" ]; then
+            echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
+            echo '⚠ ENTRA_CONFIG_JSON unset for env=prod — deploying with empty entraConfig (apps will use appsettings placeholders).' >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "entraConfig<<__EOF__"
+              echo "$ENTRA_CONFIG_JSON"
+              echo "__EOF__"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Preview infra changes (what-if — prod)
         # Prod has a required-reviewer protection rule on the GitHub Environment.
         # The what-if output is rendered to the job summary BEFORE the actual
@@ -332,6 +393,7 @@ jobs:
         # in the GitHub UI when deciding whether to approve the deploy.
         env:
           IMAGE_TAG: ${{ steps.tag.outputs.imageTag }}
+          ENTRA_CONFIG: ${{ steps.entra.outputs.entraConfig }}
         run: |
           set -euo pipefail
           {
@@ -344,7 +406,7 @@ jobs:
               --resource-group rg-ftgo-prod-eastus \
               --template-file infra/bicep/azure.bicep \
               --parameters infra/bicep/azure.prod.bicepparam \
-              --parameters imageTag="${IMAGE_TAG}" \
+              --parameters imageTag="${IMAGE_TAG}" entraConfig="${ENTRA_CONFIG}" \
               --result-format FullResourcePayloads \
               --no-pretty-print 2>&1 | tail -200 || true
             echo '```'
@@ -354,6 +416,7 @@ jobs:
         id: deploy
         env:
           IMAGE_TAG: ${{ steps.tag.outputs.imageTag }}
+          ENTRA_CONFIG: ${{ steps.entra.outputs.entraConfig }}
         run: |
           set -euo pipefail
           NAME="ftgo-prod-$(date -u +%Y%m%d%H%M%S)"
@@ -361,7 +424,7 @@ jobs:
             --resource-group rg-ftgo-prod-eastus \
             --template-file infra/bicep/azure.bicep \
             --parameters infra/bicep/azure.prod.bicepparam \
-            --parameters imageTag="${IMAGE_TAG}" \
+            --parameters imageTag="${IMAGE_TAG}" entraConfig="${ENTRA_CONFIG}" \
             --name "$NAME" \
             --only-show-errors \
             --output none

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Free-tier Azure Container Apps deployment with **dev → ppe → prod** promotio
 ```bash
 ./scripts/bootstrap-env.sh ENV=dev    # one-time: GH OIDC UAMI + RG + RPs
 git push origin main                  # auto-deploys to dev
-./scripts/provision-apps.sh ENV=dev   # one-time per env: 3 app regs + BFF FIC + MI role grants + env-var wiring
+./scripts/provision-apps.sh ENV=dev   # one-time per env (until app regs change): app regs + BFF FIC + MI grants + ENTRA_CONFIG_JSON GitHub var
 gh workflow run cd.yml -f environment=ppe   # manual promotion to ppe (later, prod)
 ```
 

--- a/docs/deploy-cloud.md
+++ b/docs/deploy-cloud.md
@@ -60,7 +60,7 @@ The workflow auto-deploys to dev. Watch progress under **Actions → CD → depl
 
 ## Provisioning per-env Entra app registrations
 
-The CD identity is intentionally scoped to ARM only (no Microsoft Graph). Entra app regs are provisioned **out-of-band**, once per env, after the first infra deploy:
+The CD identity is intentionally scoped to ARM only (no Microsoft Graph). Entra app regs and the resolved env-var wiring are provisioned **out-of-band**, once per env (or whenever app regs change):
 
 ```bash
 ./scripts/provision-apps.sh ENV=dev
@@ -69,9 +69,14 @@ The CD identity is intentionally scoped to ARM only (no Microsoft Graph). Entra 
 ```
 
 This:
-- Reads the most recent `azure.bicep` deployment outputs (BFF FQDN, ACA principal IDs).
-- Runs `main.bicep` for env-suffixed app regs (`ftgo-dev-apigateway`, ...).
-- Federates each ACA system MI to its corresponding app registration (so services can mint client assertions via MI).
+- Cold-bootstraps `azure.bicep` if no container apps exist yet (`entraConfig={}`).
+- Reads each container app's MI principalId.
+- Runs `main.bicep` to (re-)create env-suffixed app regs (`ftgo-dev-apigateway`, ...) and grant `Orders.Process` to the kitchen-worker MI.
+- Federates the BFF ACA system MI to the BFF app reg (so it can mint client assertions via MI).
+- Re-deploys `azure.bicep` with a populated `entraConfig` object — env vars now live in the bicep state, no more drift.
+- Publishes the resolved `entraConfig` JSON as the `ENTRA_CONFIG_JSON` env-level GitHub variable, so subsequent CD redeploys pass the same wiring back into bicep.
+
+After this runs once per env, every `git push origin main` fully deploys + wires the env automatically — re-running provision-apps is only needed when the Entra app regs themselves change.
 
 ## Promoting to ppe and prod
 

--- a/infra/bicep/azure.bicep
+++ b/infra/bicep/azure.bicep
@@ -25,6 +25,9 @@ param tags object = {
   managedBy:   'bicep'
 }
 
+@description('Resolved Entra wiring (tenantId, app reg appIds, kitchen-worker MI clientId, downstream FQDNs). Empty `{}` on cold deploy → apps fall back to appsettings.json placeholders. Populated by scripts/provision-apps.sh after Entra app regs and worker MI are known.')
+param entraConfig object = {}
+
 // Region → short token folded into resource names. Falls back to first 3 chars for unmapped regions.
 var regionShortMap = {
   eastus:       'eus'
@@ -92,6 +95,7 @@ module acaStack 'modules/aca-stack.bicep' = {
     containerRegistry:           containerRegistry
     imageTag:                    imageTag
     regionShort:                 regionShort
+    entraConfig:                 entraConfig
     tags:                        tags
   }
 }

--- a/infra/bicep/modules/aca-stack.bicep
+++ b/infra/bicep/modules/aca-stack.bicep
@@ -25,6 +25,9 @@ param regionShort string
 @description('Tags applied to every container app.')
 param tags object = {}
 
+@description('Resolved Entra wiring (tenantId, app reg appIds, kitchen-worker MI clientId, downstream FQDNs). Empty `{}` on cold deploy → no Entra env vars are injected and apps fall back to appsettings.json placeholders. Populated by scripts/provision-apps.sh after Entra app regs and worker MI are known.')
+param entraConfig object = {}
+
 @description('Service definitions. project = csproj folder name; shortName = lowercase image/name suffix (also used as the Bicep map key); isWebApp = whether to expose HTTP ingress + /health/live + /health/ready probes.')
 param services array = [
   { project: 'Ftgo.ApiGateway',      shortName: 'apigateway',       isWebApp: true  }
@@ -33,7 +36,77 @@ param services array = [
   { project: 'Ftgo.Kitchen.Worker',  shortName: 'kitchen-worker',   isWebApp: false }
 ]
 
-module containerApps 'container-app.bicep' = [for svc in services: {
+// `entraConfig` is treated as all-or-nothing. We require `tenantId` as the marker key
+// because partial population would silently produce broken env vars (e.g. AzureAd:ClientId
+// without AzureAd:TenantId). provision-apps.sh either populates everything or sends `{}`.
+var hasEntra = contains(entraConfig, 'tenantId')
+
+// Microsoft public-client appIds — pre-registered, well-known. Whitelisted ONLY in dev so
+// developer laptops can call dev cloud APIs via DefaultAzureCredential / AzureCliCredential.
+// ppe and prod accept tokens only from real workload identities (BFF + workers).
+//   Azure CLI:          04b07795-8ddb-461a-bbee-02f9e1bf7b46
+//   Visual Studio Code: aebc6443-996d-45c2-90f0-388ff96faa56
+var devPublicClients = environmentName == 'dev' ? [
+  '04b07795-8ddb-461a-bbee-02f9e1bf7b46'
+  'aebc6443-996d-45c2-90f0-388ff96faa56'
+] : []
+
+var apiGatewayEnv = hasEntra ? [
+  { name: 'AzureAd__TenantId',                              value: entraConfig.tenantId }
+  { name: 'AzureAd__ClientId',                              value: entraConfig.bffAppId }
+  { name: 'AzureAd__ClientCredentials__0__SourceType',      value: 'SignedAssertionFromManagedIdentity' }
+  { name: 'DownstreamApis__Orders__BaseUrl',                value: 'https://${entraConfig.ordersApiFqdn}/' }
+  { name: 'DownstreamApis__Orders__Scopes__0',              value: 'api://${entraConfig.ordersApiAppId}/orders.read' }
+  { name: 'DownstreamApis__Orders__AppPermissionScopes__0', value: 'api://${entraConfig.ordersApiAppId}/.default' }
+  { name: 'DownstreamApis__Restaurants__BaseUrl',           value: 'https://${entraConfig.restaurantsApiFqdn}/' }
+  { name: 'DownstreamApis__Restaurants__AppPermissionScopes__0', value: 'api://${entraConfig.restaurantsApiAppId}/.default' }
+] : []
+
+// Build OrdersApi allow-list: BFF first (index 0), then dev public clients (1..N), then
+// kitchen-worker MI clientId (last). Order is stable across envs because dev-only entries
+// only ever appear in dev.
+var ordersApiAllowedClientsBase = hasEntra ? concat(
+  [ entraConfig.bffAppId ],
+  devPublicClients,
+  [ entraConfig.kitchenWorkerMiClientId ]
+) : []
+var ordersApiEnv = hasEntra ? concat([
+  { name: 'AzureAd__TenantId', value: entraConfig.tenantId }
+  { name: 'AzureAd__ClientId', value: entraConfig.ordersApiAppId }
+], map(range(0, length(ordersApiAllowedClientsBase)), i => {
+  name:  'EntraAuth__AllowedClientApps__${i}'
+  value: ordersApiAllowedClientsBase[i]
+})) : []
+
+var restaurantsApiAllowedClientsBase = hasEntra ? concat(
+  [ entraConfig.bffAppId ],
+  devPublicClients
+) : []
+var restaurantsApiEnv = hasEntra ? concat([
+  { name: 'AzureAd__TenantId',                  value: entraConfig.tenantId }
+  { name: 'AzureAd__ClientId',                  value: entraConfig.restaurantsApiAppId }
+  { name: 'EntraAuth__AllowedTenantIds__0',     value: entraConfig.tenantId }
+], map(range(0, length(restaurantsApiAllowedClientsBase)), i => {
+  name:  'EntraAuth__AllowedClientApps__${i}'
+  value: restaurantsApiAllowedClientsBase[i]
+})) : []
+
+// KitchenWorker uses bare MI (no app reg). Just point it at OrdersApi.
+var kitchenWorkerEnv = hasEntra ? [
+  { name: 'Downstream__BaseUrl', value: 'https://${entraConfig.ordersApiFqdn}/' }
+  { name: 'Downstream__Scope',   value: 'api://${entraConfig.ordersApiAppId}/.default' }
+] : []
+
+// Per-service env arrays indexed by `services` ordering. Must match the canonical
+// (apigateway, orders-api, restaurants-api, kitchen-worker) order documented below.
+var serviceEnvs = [
+  apiGatewayEnv
+  ordersApiEnv
+  restaurantsApiEnv
+  kitchenWorkerEnv
+]
+
+module containerApps 'container-app.bicep' = [for (svc, i) in services: {
   name: 'aca-${svc.shortName}'
   params: {
     appName:                     'ftgo-${environmentName}-${svc.shortName}-${regionShort}'
@@ -44,6 +117,7 @@ module containerApps 'container-app.bicep' = [for svc in services: {
     appInsightsConnectionString: appInsightsConnectionString
     environmentName:             environmentName
     enableIngress:               svc.isWebApp
+    extraEnvVars:                serviceEnvs[i]
     tags:                        tags
   }
 }]

--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -36,6 +36,9 @@ param memory string = '1.0Gi'
 @description('When false, the app has no public ingress, no HTTP probe, and uses CPU-based scaling. Used for headless worker services.')
 param enableIngress bool = true
 
+@description('Per-env env-var overlay appended to the static container env (ASPNETCORE_*, APPINSIGHTS). Empty on cold deploy; populated by provision-apps.sh after Entra app regs are resolved.')
+param extraEnvVars array = []
+
 var aspNetCoreEnvironment = '${toUpper(substring(environmentName, 0, 1))}${substring(environmentName, 1)}'
 
 resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
@@ -73,7 +76,7 @@ resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
             cpu:    json(cpu)
             memory: memory
           }
-          env: [
+          env: concat([
             {
               name:  'ASPNETCORE_ENVIRONMENT'
               value: aspNetCoreEnvironment
@@ -86,7 +89,7 @@ resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
               name:  'APPLICATIONINSIGHTS_CONNECTION_STRING'
               value: appInsightsConnectionString
             }
-          ]
+          ], extraEnvVars)
           probes: enableIngress ? [
             {
               type: 'Liveness'

--- a/scripts/provision-apps.sh
+++ b/scripts/provision-apps.sh
@@ -1,25 +1,37 @@
 #!/usr/bin/env bash
-# scripts/provision-apps.sh — per-env Entra app provisioning for cloud envs (dev|ppe|prod).
+# scripts/provision-apps.sh — single deployment entrypoint for cloud envs (dev|ppe|prod).
 #
-# For each cloud env this script:
-#   1. Deploys infra/bicep/main.bicep at tenant scope to (re-)create the per-env app
-#      registrations (idempotent — Microsoft.Graph extension matches by uniqueName).
-#      It grants Orders.Process to the KitchenWorker MI's principalId so the worker
-#      can call OrdersApi using a bare ManagedIdentityCredential.
-#   2. Creates a federated identity credential on the BFF app reg trusting the BFF
-#      Container App's system MI as a SignedAssertionFromManagedIdentity issuer
-#      (the BFF's confidential-client S2S/OBO calls require an app-reg identity).
-#   3. Pushes per-env Entra config into each Container App's environment variables
-#      (TenantId, ClientId, downstream URLs/scopes, allow-lists).
+# Run this MANUALLY (requires Owner at root scope to write app regs + repo admin to write
+# GitHub vars) on a fresh env or whenever Entra app regs change. CD redeploys then pick
+# up the resolved entraConfig from the GitHub env-level variable and pass it through to
+# bicep — env vars persist across pushes (no more drift).
 #
-# ORDERING: this script depends on infra/bicep/azure.bicep already being deployed
-# for ${ENV} (typically by cd.yml). It reads the most-recent RG-scope deployment
-# outputs to discover the BFF FQDN and each ACA app's MI principalId.
+# Workflow:
+#
+#   1. (cold only) Deploy infra/bicep/azure.bicep with entraConfig={} to create the
+#      Container Apps + system MIs. Skipped when the kitchen-worker container app
+#      already exists.
+#   2. Read each container app's system-assigned MI principalId.
+#   3. Deploy infra/bicep/main.bicep at tenant scope to (re-)create the per-env Entra
+#      app registrations and grant Orders.Process to the kitchen-worker MI's principalId
+#      (Microsoft.Graph extension is idempotent — matches by uniqueName).
+#   4. Resolve the kitchen-worker MI's appId (clientId), used in OrdersApi's
+#      EntraAuth__AllowedClientApps allow-list.
+#   5. Create the federated identity credential on the BFF app reg trusting the BFF's
+#      ACA system MI as a SignedAssertionFromManagedIdentity issuer (BFF's confidential-
+#      client S2S/OBO calls require an app-reg identity).
+#   6. Re-deploy infra/bicep/azure.bicep with a populated entraConfig object. ARM merges
+#      the env-var changes into the container app templates declaratively.
+#   7. Publish entraConfig as the ENTRA_CONFIG_JSON env-level GitHub variable so cd.yml
+#      can re-pass it on subsequent CD redeploys.
+#
+# IMAGE_TAG: optional; defaults to `latest`.
 #
 # Usage:
 #   ./scripts/provision-apps.sh ENV=dev
+#   IMAGE_TAG=sha-abc1234 ./scripts/provision-apps.sh ENV=dev
 #
-# Prereqs: bash 4+, az CLI logged in (Owner at root scope to write app regs), jq.
+# Prereqs: bash 4+, az CLI logged in, gh CLI authenticated, jq.
 
 set -euo pipefail
 
@@ -31,9 +43,10 @@ fi
 ENV=""
 for arg in "$@"; do
   case "$arg" in
-    ENV=*) ENV="${arg#ENV=}" ;;
-    -h|--help) sed -n '2,21p' "$0" | sed 's/^# \?//'; exit 0 ;;
-    *) echo "unknown arg: $arg (expected ENV=dev|ppe|prod)" >&2; exit 2 ;;
+    ENV=*)        ENV="${arg#ENV=}" ;;
+    IMAGE_TAG=*)  IMAGE_TAG="${arg#IMAGE_TAG=}" ;;
+    -h|--help)    sed -n '2,38p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *)            echo "unknown arg: $arg (expected ENV=dev|ppe|prod [IMAGE_TAG=...])" >&2; exit 2 ;;
   esac
 done
 
@@ -42,7 +55,7 @@ case "$ENV" in
   *) echo "ERROR: ENV must be one of dev|ppe|prod (got '${ENV}')." >&2; exit 2 ;;
 esac
 
-for tool in az jq; do
+for tool in az jq gh; do
   command -v "$tool" >/dev/null || { echo "ERROR: '$tool' not on PATH" >&2; exit 1; }
 done
 
@@ -50,50 +63,72 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
 RG_NAME="rg-ftgo-${ENV}-eastus"
 TENANT_ID="$(az account show --query tenantId -o tsv)"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
 
-echo "==> tenant : $TENANT_ID"
-echo "==> env    : $ENV (rg=$RG_NAME)"
+# Container app names mirror the aca-stack.bicep `services` ordering.
+APIGATEWAY_NAME="ftgo-${ENV}-apigateway-eus"
+ORDERS_APP_NAME="ftgo-${ENV}-orders-api-eus"
+RESTAURANTS_APP_NAME="ftgo-${ENV}-restaurants-api-eus"
+KITCHEN_APP_NAME="ftgo-${ENV}-kitchen-worker-eus"
 
-# 1. Locate the most-recent successful azure.bicep deployment for this env.
-echo "==> Reading latest azure.bicep deployment outputs"
-LATEST_DEPLOY=$(az deployment group list \
-  --resource-group "$RG_NAME" \
-  --query "[?starts_with(name, 'ftgo-${ENV}-') && properties.provisioningState=='Succeeded'] | sort_by(@, &properties.timestamp) | [-1].name" \
-  -o tsv --only-show-errors)
-if [[ -z "$LATEST_DEPLOY" ]]; then
-  echo "ERROR: no successful RG-scope deployment 'ftgo-${ENV}-*' found in $RG_NAME. Deploy azure.bicep first." >&2
-  exit 1
+echo "==> tenant   : $TENANT_ID"
+echo "==> env      : $ENV (rg=$RG_NAME)"
+echo "==> imageTag : $IMAGE_TAG"
+
+deploy_azure_bicep() {
+  # $1 = entraConfig JSON (`{}` for cold, populated otherwise)
+  # $2 = stage name suffix (cold|wire)
+  # Status messages → stderr; deployment name → stdout (so caller can capture).
+  local entra_config_json="$1"
+  local stage="$2"
+  local name="ftgo-${ENV}-$(date -u +%Y%m%d%H%M%S)-${stage}"
+  echo "    deploying azure.bicep (name=$name, entraConfig=$([[ "$entra_config_json" == "{}" ]] && echo empty || echo populated))" >&2
+  az deployment group create \
+    --resource-group "$RG_NAME" \
+    --template-file "$ROOT/infra/bicep/azure.bicep" \
+    --parameters "$ROOT/infra/bicep/azure.${ENV}.bicepparam" \
+    --parameters imageTag="$IMAGE_TAG" entraConfig="$entra_config_json" \
+    --name "$name" \
+    --only-show-errors --output none
+  echo "$name"
+}
+
+# 1. Cold-bootstrap detection. If the kitchen-worker container app already exists, the
+#    MIs are in place and we can skip the cold azure.bicep deploy. Otherwise do a cold
+#    deploy with entraConfig={} to materialise ACA + MIs.
+echo "==> Detecting deployment state"
+if az containerapp show --name "$KITCHEN_APP_NAME" --resource-group "$RG_NAME" --only-show-errors --output none 2>/dev/null; then
+  echo "    container apps exist — skipping cold deploy"
+else
+  echo "    cold env detected — bootstrapping container apps with empty entraConfig"
+  deploy_azure_bicep '{}' 'cold' >/dev/null
 fi
-echo "    deployment = $LATEST_DEPLOY"
 
-OUTPUTS=$(az deployment group show --resource-group "$RG_NAME" --name "$LATEST_DEPLOY" --query properties.outputs -o json --only-show-errors)
-BFF_FQDN=$(jq -r '.apiGatewayFqdn.value' <<<"$OUTPUTS")
-SERVICES=$(jq -r '.services.value' <<<"$OUTPUTS")
-if [[ -z "$BFF_FQDN" || "$BFF_FQDN" == "null" ]]; then
-  echo "ERROR: deployment $LATEST_DEPLOY missing apiGatewayFqdn output." >&2
-  exit 1
-fi
-echo "    bff fqdn   = $BFF_FQDN"
+# 2. Read MI principalIds from container apps.
+echo "==> Reading container app MIs"
+APIGATEWAY_MI=$(az containerapp show --name "$APIGATEWAY_NAME"  --resource-group "$RG_NAME" --query identity.principalId -o tsv --only-show-errors)
+KITCHEN_MI=$(az    containerapp show --name "$KITCHEN_APP_NAME" --resource-group "$RG_NAME" --query identity.principalId -o tsv --only-show-errors)
+APIGATEWAY_FQDN=$(az containerapp show     --name "$APIGATEWAY_NAME"     --resource-group "$RG_NAME" --query properties.configuration.ingress.fqdn -o tsv --only-show-errors)
+ORDERS_FQDN=$(az      containerapp show     --name "$ORDERS_APP_NAME"      --resource-group "$RG_NAME" --query properties.configuration.ingress.fqdn -o tsv --only-show-errors)
+RESTAURANTS_FQDN=$(az containerapp show     --name "$RESTAURANTS_APP_NAME" --resource-group "$RG_NAME" --query properties.configuration.ingress.fqdn -o tsv --only-show-errors)
+echo "    apigateway   MI=${APIGATEWAY_MI:0:8}…  fqdn=$APIGATEWAY_FQDN"
+echo "    orders-api          fqdn=$ORDERS_FQDN"
+echo "    restaurants-api     fqdn=$RESTAURANTS_FQDN"
+echo "    kitchen-worker MI=${KITCHEN_MI:0:8}…"
 
-# Worker MI principalIds harvested from acaStack outputs — fed into permission-grants
-# so the bare-MI workers (no app reg) get their Orders.Process role admin-consented.
-KITCHEN_MI_PRINCIPAL_ID=$(jq -r '.kitchenWorker.principalId // empty' <<<"$SERVICES")
-echo "    kitchen MI = ${KITCHEN_MI_PRINCIPAL_ID:-<none>}"
-
-# 2. Tenant-scope deployment for the per-env app regs + MI role grants.
-echo "==> Deploying infra/bicep/main.bicep (env=$ENV)"
-DEPLOY_NAME="ftgo-entra-${ENV}-$(date -u +%Y%m%d%H%M%S)"
-AGW_REDIRECT="https://${BFF_FQDN}/signin-oidc"
-SCALAR_REDIRECT="https://${BFF_FQDN}/scalar/v1"
+# 3. Tenant-scope deployment for the per-env app regs + MI role grants.
+echo "==> Deploying main.bicep (env=$ENV)"
+ENTRA_DEPLOY="ftgo-entra-${ENV}-$(date -u +%Y%m%d%H%M%S)"
+AGW_REDIRECT="https://${APIGATEWAY_FQDN}/signin-oidc"
+SCALAR_REDIRECT="https://${APIGATEWAY_FQDN}/scalar/v1"
 
 # main.${ENV}.bicepparam reads AZURE_TENANT_ID via readEnvironmentVariable.
 export AZURE_TENANT_ID="$TENANT_ID"
 
-WORKER_MI_JSON=$(jq -nc --arg k "$KITCHEN_MI_PRINCIPAL_ID" \
-  'if $k == "" then {} else {kitchenWorker: $k} end')
+WORKER_MI_JSON=$(jq -nc --arg k "$KITCHEN_MI" '{kitchenWorker: $k}')
 
 az deployment tenant create \
-  --name "$DEPLOY_NAME" \
+  --name "$ENTRA_DEPLOY" \
   --location eastus \
   --template-file "$ROOT/infra/bicep/main.bicep" \
   --parameters "$ROOT/infra/bicep/main.${ENV}.bicepparam" \
@@ -103,152 +138,98 @@ az deployment tenant create \
       workerMiPrincipalIds="$WORKER_MI_JSON" \
   --only-show-errors --output none
 
-APPS=$(az deployment tenant show --name "$DEPLOY_NAME" --query 'properties.outputs.apps.value' -o json --only-show-errors)
+APPS=$(az deployment tenant show --name "$ENTRA_DEPLOY" --query 'properties.outputs.apps.value' -o json --only-show-errors)
+BFF_APPID=$(jq         -r '.apiGateway.appId'     <<<"$APPS")
+ORDERS_APPID=$(jq      -r '.ordersApi.appId'      <<<"$APPS")
+RESTAURANTS_APPID=$(jq -r '.restaurantsApi.appId' <<<"$APPS")
+echo "    bff appId             = $BFF_APPID"
+echo "    orders-api appId      = $ORDERS_APPID"
+echo "    restaurants-api appId = $RESTAURANTS_APPID"
 
-# 3. Federated identity credential on the BFF app reg ← BFF ACA system MI.
-#
-# SignedAssertionFromManagedIdentity flow: the BFF uses its system-assigned MI to mint a
-# token with audience `api://AzureADTokenExchange`. The BFF app reg trusts that token via
-# a federated credential whose issuer is the tenant's STS, subject is the MI's clientId.
-# Then the BFF can do confidential-client S2S/OBO calls under its app-reg identity without
-# any cert or secret on the box.
-#
-# Workers (Kitchen) do NOT need this — they call APIs as the MI directly (see Phase 2 docs).
+# 4. Resolve kitchen-worker MI clientId (appId, not principalId). Required so OrdersApi
+#    can match the worker's `azp` claim against EntraAuth__AllowedClientApps.
+echo "==> Resolving kitchen-worker MI clientId"
+KITCHEN_MI_CLIENT_ID=$(az ad sp show --id "$KITCHEN_MI" --query appId -o tsv --only-show-errors)
+echo "    kitchen-worker clientId = $KITCHEN_MI_CLIENT_ID"
 
+# 5. Federated identity credential on the BFF app reg ← BFF ACA system MI.
+#
+#    SignedAssertionFromManagedIdentity flow: the BFF uses its system-assigned MI to mint
+#    a token with audience `api://AzureADTokenExchange`. The BFF app reg trusts that
+#    token via a federated credential whose issuer is the tenant STS, subject is the MI's
+#    clientId. Then the BFF can do confidential-client S2S/OBO calls under its app-reg
+#    identity without any cert or secret on the box.
+#
+#    Workers (Kitchen) do NOT need this — they call APIs as the MI directly.
 echo "==> Federated identity credential (BFF app reg ← BFF MI)"
 ISSUER="https://login.microsoftonline.com/${TENANT_ID}/v2.0"
+BFF_APP_OBJ_ID=$(az ad app show --id "$BFF_APPID" --query id -o tsv --only-show-errors)
+BFF_MI_CLIENT_ID=$(az ad sp show --id "$APIGATEWAY_MI" --query appId -o tsv --only-show-errors)
+BFF_FIC_NAME="aca-${ENV}-apigateway"
 
-bff_app_id=$(jq -r '.apiGateway.appId' <<<"$APPS")
-bff_app_obj_id=$(az ad app show --id "$bff_app_id" --query id -o tsv --only-show-errors)
-bff_mi_principal_id=$(jq -r '.apiGateway.principalId' <<<"$SERVICES")
-bff_mi_client_id=$(az ad sp show --id "$bff_mi_principal_id" --query appId -o tsv --only-show-errors)
-bff_fic_name="aca-${ENV}-apigateway"
-
-if az ad app federated-credential list --id "$bff_app_obj_id" \
-      --query "[?name=='${bff_fic_name}']" -o tsv --only-show-errors 2>/dev/null | grep -q .; then
-  echo "    FIC '${bff_fic_name}' already exists"
+if az ad app federated-credential list --id "$BFF_APP_OBJ_ID" \
+      --query "[?name=='${BFF_FIC_NAME}']" -o tsv --only-show-errors 2>/dev/null | grep -q .; then
+  echo "    FIC '${BFF_FIC_NAME}' already exists"
 else
-  az ad app federated-credential create --id "$bff_app_obj_id" --parameters "$(jq -nc \
-    --arg name "$bff_fic_name" --arg issuer "$ISSUER" --arg sub "$bff_mi_client_id" '{
+  az ad app federated-credential create --id "$BFF_APP_OBJ_ID" --parameters "$(jq -nc \
+    --arg name "$BFF_FIC_NAME" --arg issuer "$ISSUER" --arg sub "$BFF_MI_CLIENT_ID" '{
       name: $name,
       issuer: $issuer,
       subject: $sub,
       description: "ACA system MI → BFF app reg (SignedAssertionFromManagedIdentity)",
       audiences: ["api://AzureADTokenExchange"]
     }')" --only-show-errors --output none
-  echo "    created FIC '${bff_fic_name}' (subject=${bff_mi_client_id})"
+  echo "    created FIC '${BFF_FIC_NAME}' (subject=${BFF_MI_CLIENT_ID})"
+fi
+
+# 6. Build full entraConfig and re-deploy azure.bicep. This is the step that wires env
+#    vars into the container app templates declaratively; subsequent CD redeploys with
+#    the same entraConfig will be no-ops on env vars.
+echo "==> Wiring entraConfig into azure.bicep"
+ENTRA_CONFIG_JSON=$(jq -nc \
+  --arg tenantId                 "$TENANT_ID" \
+  --arg bffAppId                 "$BFF_APPID" \
+  --arg ordersApiAppId           "$ORDERS_APPID" \
+  --arg restaurantsApiAppId      "$RESTAURANTS_APPID" \
+  --arg kitchenWorkerMiClientId  "$KITCHEN_MI_CLIENT_ID" \
+  --arg ordersApiFqdn            "$ORDERS_FQDN" \
+  --arg restaurantsApiFqdn       "$RESTAURANTS_FQDN" \
+  '{
+    tenantId:                $tenantId,
+    bffAppId:                $bffAppId,
+    ordersApiAppId:          $ordersApiAppId,
+    restaurantsApiAppId:     $restaurantsApiAppId,
+    kitchenWorkerMiClientId: $kitchenWorkerMiClientId,
+    ordersApiFqdn:           $ordersApiFqdn,
+    restaurantsApiFqdn:      $restaurantsApiFqdn
+  }')
+
+WIRE_DEPLOY=$(deploy_azure_bicep "$ENTRA_CONFIG_JSON" 'wire')
+
+# 7. Write entraConfig to the env-level GitHub variable consumed by cd.yml. CD reads
+#    `${{ vars.ENTRA_CONFIG_JSON }}` and passes it back into azure.bicep on every
+#    redeploy, so env vars persist across pushes.
+echo "==> Publishing ENTRA_CONFIG_JSON GitHub env var (env=$ENV)"
+if gh variable set ENTRA_CONFIG_JSON --env "$ENV" --body "$ENTRA_CONFIG_JSON" 2>/dev/null; then
+  echo "    set ENTRA_CONFIG_JSON in GitHub environment '$ENV'"
+else
+  cat <<EOF >&2
+    WARNING: failed to write ENTRA_CONFIG_JSON via 'gh variable set' — gh may not be
+    authenticated or the env '$ENV' may not exist as a GitHub Environment yet.
+    Set it manually so cd.yml will pick it up on the next push:
+      gh variable set ENTRA_CONFIG_JSON --env $ENV --body '$ENTRA_CONFIG_JSON'
+EOF
 fi
 
 cat <<EOF
 
 ============================================================
-Per-env Entra provisioning complete for ${ENV}.
-  - tenant deployment: $DEPLOY_NAME
+Provisioning complete for ${ENV}.
+  - tenant deployment: $ENTRA_DEPLOY
+  - infra deployment:  $WIRE_DEPLOY
   - BFF redirect URI:  $AGW_REDIRECT
   - Scalar redirect:   $SCALAR_REDIRECT
-============================================================
-EOF
-
-# 4. Wire Entra config into each Container App's environment variables.
-#
-# appsettings.json ships with placeholder GUIDs. .NET config binds env vars with '__'
-# as the section separator and overrides JSON, so we push the per-env values here.
-#
-# NOTE: this wiring is imperative and gets clobbered on every azure.bicep redeploy.
-# Phase 3 of the refactor moves these into bicep params for declarative wiring.
-
-echo
-echo "==> Wiring Entra config into Container App env vars"
-
-ORDER_FQDN=$(jq -r '.ordersApi.fqdn'      <<<"$SERVICES")
-REST_FQDN=$(jq  -r '.restaurantsApi.fqdn' <<<"$SERVICES")
-ORDER_APPID=$(jq -r '.ordersApi.appId'      <<<"$APPS")
-REST_APPID=$(jq  -r '.restaurantsApi.appId' <<<"$APPS")
-BFF_APPID=$(jq   -r '.apiGateway.appId'     <<<"$APPS")
-
-set_env() {
-  local app_name="$1"; shift
-  echo "    $app_name"
-  for kv in "$@"; do echo "      $kv"; done
-  az containerapp update --name "$app_name" --resource-group "$RG_NAME" \
-    --set-env-vars "$@" --only-show-errors --output none
-}
-
-# 4a. AzureAd__TenantId / AzureAd__ClientId on every app that has its own app reg
-#     (BFF + 2 APIs). KitchenWorker uses MI directly and reads no AzureAd:* values.
-for key in apiGateway ordersApi restaurantsApi; do
-  app_id=$(jq -r --arg k "$key" '.[$k].appId' <<<"$APPS")
-  app_name=$(jq -r --arg k "$key" '.[$k].name // empty' <<<"$SERVICES")
-  [[ -z "$app_name" ]] && continue
-  set_env "$app_name" \
-    "AzureAd__TenantId=$TENANT_ID" \
-    "AzureAd__ClientId=$app_id"
-done
-
-# 4b. BFF (apigateway): DownstreamApis routing + URLs.
-BFF_APP_NAME=$(jq -r '.apiGateway.name' <<<"$SERVICES")
-set_env "$BFF_APP_NAME" \
-  "AzureAd__ClientCredentials__0__SourceType=SignedAssertionFromManagedIdentity" \
-  "DownstreamApis__Orders__BaseUrl=https://${ORDER_FQDN}/" \
-  "DownstreamApis__Orders__Scopes__0=api://${ORDER_APPID}/orders.read" \
-  "DownstreamApis__Orders__AppPermissionScopes__0=api://${ORDER_APPID}/.default" \
-  "DownstreamApis__Restaurants__BaseUrl=https://${REST_FQDN}/" \
-  "DownstreamApis__Restaurants__AppPermissionScopes__0=api://${REST_APPID}/.default"
-
-# 4c. KitchenWorker: bare MI, no app reg. Just point it at OrdersApi.
-KITC_APP_NAME=$(jq -r '.kitchenWorker.name' <<<"$SERVICES")
-[[ -n "$KITC_APP_NAME" ]] && set_env "$KITC_APP_NAME" \
-  "Downstream__BaseUrl=https://${ORDER_FQDN}/" \
-  "Downstream__Scope=api://${ORDER_APPID}/.default"
-
-# Microsoft public client appIds — pre-registered, well-known, used as the developer's
-# local identity via DefaultAzureCredential / AzureCliCredential. Whitelisted ONLY in
-# the dev env so a laptop can hit dev cloud APIs with `az account get-access-token`.
-# ppe and prod accept tokens only from real workload identities (BFF).
-#   Azure CLI:  04b07795-8ddb-461a-bbee-02f9e1bf7b46
-#   Visual Studio Code: aebc6443-996d-45c2-90f0-388ff96faa56
-ORDER_DEV_CLIENTS=()
-REST_DEV_CLIENTS=()
-if [[ "$ENV" == "dev" ]]; then
-  ORDER_DEV_CLIENTS=(
-    "EntraAuth__AllowedClientApps__1=04b07795-8ddb-461a-bbee-02f9e1bf7b46"
-    "EntraAuth__AllowedClientApps__2=aebc6443-996d-45c2-90f0-388ff96faa56"
-  )
-  REST_DEV_CLIENTS=(
-    "EntraAuth__AllowedClientApps__1=04b07795-8ddb-461a-bbee-02f9e1bf7b46"
-    "EntraAuth__AllowedClientApps__2=aebc6443-996d-45c2-90f0-388ff96faa56"
-  )
-fi
-
-# 4d. OrdersApi: AllowedClientApps whitelist (BFF, plus dev tools when env=dev).
-#     The KitchenWorker MI's appId could be added too, but `RequireClientApp` checks `azp`
-#     against this list — for MI tokens `azp` IS the MI clientId, so add it explicitly.
-KITC_MI_CLIENT_ID=""
-if [[ -n "$KITCHEN_MI_PRINCIPAL_ID" ]]; then
-  KITC_MI_CLIENT_ID=$(az ad sp show --id "$KITCHEN_MI_PRINCIPAL_ID" --query appId -o tsv --only-show-errors 2>/dev/null || echo "")
-fi
-ORDER_APP_NAME=$(jq -r '.ordersApi.name' <<<"$SERVICES")
-ORDER_ENV=(
-  "EntraAuth__AllowedClientApps__0=$BFF_APPID"
-  "${ORDER_DEV_CLIENTS[@]}"
-)
-if [[ -n "$KITC_MI_CLIENT_ID" ]]; then
-  # Append after dev-tools to keep dev-tool indices stable across env=dev/ppe/prod.
-  ORDER_ENV+=("EntraAuth__AllowedClientApps__3=$KITC_MI_CLIENT_ID")
-fi
-set_env "$ORDER_APP_NAME" "${ORDER_ENV[@]}"
-
-# 4e. RestaurantsApi (multi-tenant): pin allowed tenant + BFF (plus dev tools when env=dev).
-REST_APP_NAME=$(jq -r '.restaurantsApi.name' <<<"$SERVICES")
-set_env "$REST_APP_NAME" \
-  "EntraAuth__AllowedTenantIds__0=$TENANT_ID" \
-  "EntraAuth__AllowedClientApps__0=$BFF_APPID" \
-  "${REST_DEV_CLIENTS[@]}"
-
-cat <<EOF
-
-============================================================
-Container App env vars wired for ${ENV}.
-Browser flow: https://${BFF_FQDN}/signin-oidc
+  - BFF URL:           https://${APIGATEWAY_FQDN}
+  - GitHub env var:    ENTRA_CONFIG_JSON (env=$ENV)
 ============================================================
 EOF


### PR DESCRIPTION
## Problem

CD redeploys of `azure.bicep` clobbered the env vars set imperatively by `provision-apps.sh` (`AzureAd:*`, `DownstreamApis:*`, `EntraAuth:AllowedClientApps`). Every push to `main` required a manual provision-apps re-run to restore wiring.

## Fix

Move env-var wiring **into Bicep** as a typed `entraConfig` object param. `provision-apps.sh` resolves the values once per env and writes them to a GitHub env-level variable (`ENTRA_CONFIG_JSON`); CD reads it back on every redeploy.

## Design (after rubber-duck critique)

The first design (read-back from deployment history) had 4 blockers — migration regression, imageTag drift, stale state from history queries, and missing kitchen MI clientId lookup. Final design addresses all four:

- **`container-app.bicep`** — new `extraEnvVars array = []` param appended to env array.
- **`aca-stack.bicep`** — new `entraConfig object = {}` param. Computes per-service env arrays from the typed object: tenantId, BFF/orders/restaurants appIds, kitchen-worker MI clientId, downstream FQDNs. All-or-nothing semantics gated on `contains(entraConfig, 'tenantId')`. Dev-only AzCli/VS Code allow-list entries computed in Bicep.
- **`azure.bicep`** — threads `entraConfig` to `aca-stack`.
- **`provision-apps.sh`** — manual orchestrator (Owner + `gh`). Cold-bootstrap detection via `az containerapp show`; reads MIs/FQDNs directly from container apps; resolves kitchen-worker MI clientId via `az ad sp show`; re-deploys `azure.bicep` with populated `entraConfig`; writes JSON to `ENTRA_CONFIG_JSON` env-level GitHub variable.
- **`cd.yml`** — new `Resolve entraConfig` step per env (dev/ppe/prod). Falls back to `{}` on cold envs with a summary warning. What-if and deploy steps pass `entraConfig` through.

## Permissions

CD UAMI keeps RG-Contributor only — does NOT get Microsoft Graph / tenant scope. App reg lifecycle stays operator-driven.

## Validation

- `dotnet build` — 0 warnings, 27/27 tests pass.
- `az bicep build infra/bicep/azure.bicep` — clean.
- `bash -n scripts/provision-apps.sh` — clean.
- YAML syntax — valid.

## Migration

Existing dev env: operator runs `./scripts/provision-apps.sh ENV=dev` once after merge → `ENTRA_CONFIG_JSON` GitHub var is set → next CD push picks it up. No regression on already-working envs because the script writes the var BEFORE the next CD runs.
