### PR TITLE
fix(cd): warm-env clobber guard for ENTRA_CONFIG_JSON

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -140,28 +140,49 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Resolve entraConfig
+      - name: Resolve entraConfig (with warm-env guard)
         id: entra
         env:
           ENTRA_CONFIG_JSON: ${{ vars.ENTRA_CONFIG_JSON }}
+          RG: rg-ftgo-dev-eastus
+          APP: ftgo-dev-apigateway-eus
+          ENV_NAME: dev
         run: |
           set -euo pipefail
-          # ENTRA_CONFIG_JSON is written as a GitHub env-level variable by
-          # `scripts/provision-apps.sh ENV=dev` (manual, one-time per env or when app
-          # regs change). Falls back to `{}` for cold envs where provisioning hasn't
-          # happened yet — the deploy still succeeds, apps come up with appsettings
-          # placeholders, and the operator runs provision-apps.sh once to populate.
-          if [ -z "${ENTRA_CONFIG_JSON}" ]; then
-            echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
-            echo '⚠ ENTRA_CONFIG_JSON unset for env=dev — deploying with empty entraConfig (apps will use appsettings placeholders).' >> "$GITHUB_STEP_SUMMARY"
-          else
-            # Use a heredoc-safe delimiter so multiline JSON survives intact.
+          if [ -n "${ENTRA_CONFIG_JSON}" ]; then
             {
               echo "entraConfig<<__EOF__"
               echo "$ENTRA_CONFIG_JSON"
               echo "__EOF__"
             } >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          # ENTRA_CONFIG_JSON missing. Distinguish a true-cold env (apps don't exist yet
+          # → safe to deploy with `{}`) from a warm env that's already running with env
+          # vars set imperatively by an earlier provision-apps.sh run (would CLOBBER
+          # those env vars and break auth). Only the cold case is allowed to proceed.
+          if ! az containerapp show --name "$APP" --resource-group "$RG" --only-show-errors --output none 2>/dev/null; then
+            echo "Cold env detected (no $APP container app) — proceeding with entraConfig={}." >&2
+            echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
+            echo "⚠ ENTRA_CONFIG_JSON unset and env=$ENV_NAME is cold — deploying with empty entraConfig. Run \`./scripts/provision-apps.sh ENV=$ENV_NAME\` after the deploy completes to wire Entra config." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          HAS_TENANT=$(az containerapp show --name "$APP" --resource-group "$RG" --query "properties.template.containers[0].env[?name=='AzureAd__TenantId'] | length(@)" -o tsv --only-show-errors)
+          if [ "${HAS_TENANT:-0}" -gt 0 ]; then
+            {
+              echo "ERROR: warm env=$ENV_NAME has live Entra env vars on $APP, but the"
+              echo "       ENTRA_CONFIG_JSON GitHub variable is unset. Deploying now would"
+              echo "       declaratively REMOVE those env vars and break auth."
+              echo ""
+              echo "       Run on a workstation with Owner + gh:"
+              echo "         ./scripts/provision-apps.sh ENV=$ENV_NAME"
+              echo "       (sets the ENTRA_CONFIG_JSON env-level GitHub variable + re-wires)"
+              echo "       then re-run this workflow."
+            } >&2
+            exit 1
+          fi
+          echo "Warm env=$ENV_NAME but no Entra env vars present — proceeding with entraConfig={}." >&2
+          echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
 
       - name: Preview infra changes (what-if — dev)
         env:
@@ -259,22 +280,30 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Resolve entraConfig
+      - name: Resolve entraConfig (with warm-env guard)
         id: entra
         env:
           ENTRA_CONFIG_JSON: ${{ vars.ENTRA_CONFIG_JSON }}
+          RG: rg-ftgo-ppe-eastus
+          APP: ftgo-ppe-apigateway-eus
+          ENV_NAME: ppe
         run: |
           set -euo pipefail
-          if [ -z "${ENTRA_CONFIG_JSON}" ]; then
-            echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
-            echo '⚠ ENTRA_CONFIG_JSON unset for env=ppe — deploying with empty entraConfig (apps will use appsettings placeholders).' >> "$GITHUB_STEP_SUMMARY"
-          else
-            {
-              echo "entraConfig<<__EOF__"
-              echo "$ENTRA_CONFIG_JSON"
-              echo "__EOF__"
-            } >> "$GITHUB_OUTPUT"
+          if [ -n "${ENTRA_CONFIG_JSON}" ]; then
+            { echo "entraConfig<<__EOF__"; echo "$ENTRA_CONFIG_JSON"; echo "__EOF__"; } >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          if ! az containerapp show --name "$APP" --resource-group "$RG" --only-show-errors --output none 2>/dev/null; then
+            echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
+            echo "⚠ ENTRA_CONFIG_JSON unset and env=$ENV_NAME is cold — deploying with empty entraConfig. Run \`./scripts/provision-apps.sh ENV=$ENV_NAME\` after." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          HAS_TENANT=$(az containerapp show --name "$APP" --resource-group "$RG" --query "properties.template.containers[0].env[?name=='AzureAd__TenantId'] | length(@)" -o tsv --only-show-errors)
+          if [ "${HAS_TENANT:-0}" -gt 0 ]; then
+            echo "ERROR: warm env=$ENV_NAME would clobber Entra env vars; ENTRA_CONFIG_JSON GitHub var is unset. Run ./scripts/provision-apps.sh ENV=$ENV_NAME and re-run." >&2
+            exit 1
+          fi
+          echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
 
       - name: Preview infra changes (what-if — ppe)
         env:
@@ -369,22 +398,30 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Resolve entraConfig
+      - name: Resolve entraConfig (with warm-env guard)
         id: entra
         env:
           ENTRA_CONFIG_JSON: ${{ vars.ENTRA_CONFIG_JSON }}
+          RG: rg-ftgo-prod-eastus
+          APP: ftgo-prod-apigateway-eus
+          ENV_NAME: prod
         run: |
           set -euo pipefail
-          if [ -z "${ENTRA_CONFIG_JSON}" ]; then
-            echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
-            echo '⚠ ENTRA_CONFIG_JSON unset for env=prod — deploying with empty entraConfig (apps will use appsettings placeholders).' >> "$GITHUB_STEP_SUMMARY"
-          else
-            {
-              echo "entraConfig<<__EOF__"
-              echo "$ENTRA_CONFIG_JSON"
-              echo "__EOF__"
-            } >> "$GITHUB_OUTPUT"
+          if [ -n "${ENTRA_CONFIG_JSON}" ]; then
+            { echo "entraConfig<<__EOF__"; echo "$ENTRA_CONFIG_JSON"; echo "__EOF__"; } >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          if ! az containerapp show --name "$APP" --resource-group "$RG" --only-show-errors --output none 2>/dev/null; then
+            echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
+            echo "⚠ ENTRA_CONFIG_JSON unset and env=$ENV_NAME is cold — deploying with empty entraConfig. Run \`./scripts/provision-apps.sh ENV=$ENV_NAME\` after." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          HAS_TENANT=$(az containerapp show --name "$APP" --resource-group "$RG" --query "properties.template.containers[0].env[?name=='AzureAd__TenantId'] | length(@)" -o tsv --only-show-errors)
+          if [ "${HAS_TENANT:-0}" -gt 0 ]; then
+            echo "ERROR: warm env=$ENV_NAME would clobber Entra env vars; ENTRA_CONFIG_JSON GitHub var is unset. Run ./scripts/provision-apps.sh ENV=$ENV_NAME and re-run." >&2
+            exit 1
+          fi
+          echo 'entraConfig={}' >> "$GITHUB_OUTPUT"
 
       - name: Preview infra changes (what-if — prod)
         # Prod has a required-reviewer protection rule on the GitHub Environment.


### PR DESCRIPTION
## Why

Code-review on PR #32 caught a real issue post-merge: when CD runs on a warm env where `ENTRA_CONFIG_JSON` is unset (e.g. immediately after this declarative-wiring change merges, before the operator has run `provision-apps.sh`), CD silently deploys with `entraConfig={}` and ARM declaratively REMOVES every `AzureAd__*` / `DownstreamApis__*` / `EntraAuth__*` env var on the live container apps — breaking auth.

PR #32 already auto-merged → in-flight CD clobbered dev (operator needs to run `./scripts/provision-apps.sh ENV=dev` to restore). This hotfix prevents the same fate for ppe/prod when those next deploy.

## How

3-state guard in the `Resolve entraConfig` step per env:

| State | `ENTRA_CONFIG_JSON` | Container apps | Behaviour |
|---|---|---|---|
| Normal warm | set | exist | Use it |
| True cold | unset | absent | Deploy with `{}` (warns in summary) |
| Warm + missing var | unset | exist + AzureAd__TenantId present | **Fail loud** — operator must run `provision-apps.sh ENV=<env>` |

Detection only reads (`az containerapp show --query "...env[?name=='AzureAd__TenantId'] | length(@)"`); no risk of side-effects pre-deploy.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cd.yml'))"` — clean
- All 3 env jobs (dev/ppe/prod) updated with identical logic, parameterised on `RG`/`APP`/`ENV_NAME`
