### PR TITLE
feat(observability): named ActivitySource for BFF auth flows

### DIFF
--- a/src/Ftgo.ApiGateway/BffActivitySource.cs
+++ b/src/Ftgo.ApiGateway/BffActivitySource.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Ftgo.ApiGateway;
+
+/// <summary>
+/// Custom <see cref="ActivitySource"/> for BFF flows. Wraps each downstream call (OBO,
+/// app-only / S2S, multi-tenant S2S) in a named span so the trace tree in App Insights
+/// or Jaeger shows the auth flow explicitly (e.g. <c>bff.checkout.via_obo</c>) instead of
+/// just the underlying outgoing HTTP request.
+/// </summary>
+/// <remarks>
+/// Registered via <c>AddEntraAuthWebTelemetry("Ftgo.ApiGateway", BffActivitySource.Name)</c>.
+/// Span tags use the OTel semantic conventions where possible:
+/// <list type="bullet">
+///   <item><c>ftgo.auth.flow</c> — <c>obo</c> | <c>app_only</c> | <c>app_only_multitenant</c></item>
+///   <item><c>ftgo.downstream.api</c> — logical downstream name (Orders, Restaurants)</item>
+/// </list>
+/// </remarks>
+public static class BffActivitySource
+{
+    public const string Name = "Ftgo.ApiGateway.Bff";
+
+    public static readonly ActivitySource Instance = new(
+        Name,
+        typeof(BffActivitySource).Assembly.GetName().Version?.ToString() ?? "0.0.0");
+}

--- a/src/Ftgo.ApiGateway/Controllers/CheckoutController.cs
+++ b/src/Ftgo.ApiGateway/Controllers/CheckoutController.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Identity.Abstractions;
@@ -14,6 +15,10 @@ public sealed class CheckoutController(IDownstreamApi downstream, IConfiguration
     [RequiredScope("orders.read")]
     public async Task<IActionResult> ViaObo()
     {
+        using var activity = BffActivitySource.Instance.StartActivity("bff.checkout.via_obo", ActivityKind.Internal);
+        activity?.SetTag("ftgo.auth.flow", "obo");
+        activity?.SetTag("ftgo.downstream.api", "Orders");
+
         var resp = await downstream.CallApiForUserAsync("Orders", o => o.RelativePath = "api/orders/whoami");
         var body = await resp.Content.ReadAsStringAsync();
         return Content(body, "application/json");
@@ -23,6 +28,10 @@ public sealed class CheckoutController(IDownstreamApi downstream, IConfiguration
     [RequiredScope("orders.read")]
     public async Task<IActionResult> ViaS2S()
     {
+        using var activity = BffActivitySource.Instance.StartActivity("bff.checkout.via_s2s", ActivityKind.Internal);
+        activity?.SetTag("ftgo.auth.flow", "app_only");
+        activity?.SetTag("ftgo.downstream.api", "Orders");
+
         var resp = await downstream.CallApiForAppAsync("Orders", o =>
         {
             o.RelativePath = "api/orders/system";
@@ -36,6 +45,10 @@ public sealed class CheckoutController(IDownstreamApi downstream, IConfiguration
     [RequiredScope("orders.read")]
     public async Task<IActionResult> ViaS2SMultiTenant()
     {
+        using var activity = BffActivitySource.Instance.StartActivity("bff.checkout.via_s2s_multitenant", ActivityKind.Internal);
+        activity?.SetTag("ftgo.auth.flow", "app_only_multitenant");
+        activity?.SetTag("ftgo.downstream.api", "Restaurants");
+
         var resp = await downstream.CallApiForAppAsync("Restaurants", o =>
         {
             o.RelativePath = "api/restaurants/system";

--- a/src/Ftgo.ApiGateway/Program.cs
+++ b/src/Ftgo.ApiGateway/Program.cs
@@ -1,3 +1,4 @@
+using Ftgo.ApiGateway;
 using Ftgo.Auth;
 using Microsoft.Identity.Web;
 
@@ -10,7 +11,7 @@ builder.Services.AddEntraAuth(builder.Configuration, auth =>
         .AddDownstreamApi("Restaurants", builder.Configuration.GetSection("DownstreamApis:Restaurants"))
         .AddDistributedTokenCaches();
 });
-builder.Services.AddEntraAuthWebTelemetry("Ftgo.ApiGateway");
+builder.Services.AddEntraAuthWebTelemetry("Ftgo.ApiGateway", BffActivitySource.Name);
 builder.Services.AddEntraAuthProblemDetails();
 builder.Services.AddEntraAuthOpenApi(builder.Configuration, "orders.read");
 builder.Services.AddHealthChecks();

--- a/src/Ftgo.Auth.Client/TelemetryExtensions.cs
+++ b/src/Ftgo.Auth.Client/TelemetryExtensions.cs
@@ -14,7 +14,8 @@ public static class TelemetryExtensions
 {
     public static IServiceCollection AddEntraAuthTelemetry(
         this IServiceCollection services,
-        string serviceName)
+        string serviceName,
+        params string[] additionalActivitySources)
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
@@ -30,6 +31,10 @@ public static class TelemetryExtensions
             .WithTracing(t =>
             {
                 t.AddHttpClientInstrumentation();
+                foreach (var source in additionalActivitySources)
+                {
+                    t.AddSource(source);
+                }
                 if (hasOtlp) t.AddOtlpExporter();
                 if (hasAzureMonitor) t.AddAzureMonitorTraceExporter(o => o.ConnectionString = aiConnectionString);
             })

--- a/src/Ftgo.Auth/WebTelemetryExtensions.cs
+++ b/src/Ftgo.Auth/WebTelemetryExtensions.cs
@@ -8,11 +8,12 @@ public static class WebTelemetryExtensions
 {
     public static IServiceCollection AddEntraAuthWebTelemetry(
         this IServiceCollection services,
-        string serviceName)
+        string serviceName,
+        params string[] additionalActivitySources)
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.AddEntraAuthTelemetry(serviceName);
+        services.AddEntraAuthTelemetry(serviceName, additionalActivitySources);
 
         services
             .AddOpenTelemetry()


### PR DESCRIPTION
## Why

In App Insights / Jaeger today, a BFF checkout shows up as a generic outgoing HTTP request to Orders / Restaurants. You can't tell *which auth flow* (OBO vs app-only vs multi-tenant) produced the call without reading the code. That makes triage of auth-shaped failures (e.g. "OBO is failing for users in tenant X") slower than it should be.

## What

A small custom `ActivitySource` (`Ftgo.ApiGateway.Bff`) emits a named span per BFF flow:

| Span name | Tag `ftgo.auth.flow` |
|---|---|
| `bff.checkout.via_obo` | `obo` |
| `bff.checkout.via_s2s` | `app_only` |
| `bff.checkout.via_s2s_multitenant` | `app_only_multitenant` |

Every span also carries `ftgo.downstream.api={Orders|Restaurants}` for slicing.

## Plumbing

- `Ftgo.Auth.Client.TelemetryExtensions.AddEntraAuthTelemetry` now takes `params string[] additionalActivitySources` and `AddSource()`s each one onto the tracer.
- `Ftgo.Auth.WebTelemetryExtensions.AddEntraAuthWebTelemetry` forwards the same `params`.
- `Program.cs` registers `BffActivitySource.Name` so spans are actually exported.

Backwards-compatible — every other service's `Program.cs` keeps compiling without changes.

## Verification

- `dotnet build` — 0 warnings, 0 errors
- `dotnet test` — 27/27 passing
- `dotnet format --verify-no-changes` — clean