### PR TITLE
chore(bicep): enable strict linter rules + fail CI on any warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,30 @@ jobs:
       - name: Install Bicep CLI
         run: az bicep install
 
-      - name: Bicep build (lints templates)
+      - name: Bicep build (templates + modules) — fail on any warning
+        # az bicep build runs the linter using infra/bicep/bicepconfig.json.
+        # We tee stderr+stdout, then fail if any "Warning" or "Error" line slipped through
+        # (ARM build itself only fails on errors, but our bicepconfig has strict rules
+        # that emit warnings — those should block CI).
         run: |
-          az bicep build --file infra/bicep/main.bicep      --outdir /tmp/bicep-out
-          az bicep build --file infra/bicep/azure.bicep     --outdir /tmp/bicep-out
-          az bicep build --file infra/bicep/bootstrap.bicep --outdir /tmp/bicep-out
-          echo "main.bicep + azure.bicep + bootstrap.bicep + modules built clean"
+          set -euo pipefail
+          mkdir -p /tmp/bicep-out
+          fail=0
+          for f in infra/bicep/main.bicep infra/bicep/azure.bicep infra/bicep/bootstrap.bicep infra/bicep/modules/*.bicep; do
+            echo "::group::bicep build $f"
+            out=$(az bicep build --file "$f" --outdir /tmp/bicep-out 2>&1 || true)
+            echo "$out"
+            echo "::endgroup::"
+            if echo "$out" | grep -E ' : (Warning|Error) ' >/dev/null; then
+              echo "::error file=$f::bicep lint warning/error in $f"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::bicep lint failures found — see grouped output above"
+            exit 1
+          fi
+          echo "All bicep templates + modules built clean (zero warnings)."
 
       - name: Bicep build-params
         env:
@@ -90,8 +108,21 @@ jobs:
           GH_OWNER:        mghabin
           GH_REPO:         entra-auth-patterns-dotnet
         run: |
+          set -euo pipefail
+          fail=0
           for env in dev ppe prod; do
-            az bicep build-params --file "infra/bicep/main.${env}.bicepparam"      --outfile "/tmp/bicep-out/main.${env}.parameters.json"
-            az bicep build-params --file "infra/bicep/bootstrap.${env}.bicepparam" --outfile "/tmp/bicep-out/bootstrap.${env}.parameters.json"
+            for stem in main bootstrap azure; do
+              file="infra/bicep/${stem}.${env}.bicepparam"
+              [ -f "$file" ] || continue
+              echo "::group::bicep build-params $file"
+              out=$(az bicep build-params --file "$file" --outfile "/tmp/bicep-out/${stem}.${env}.parameters.json" 2>&1 || true)
+              echo "$out"
+              echo "::endgroup::"
+              if echo "$out" | grep -E ' : (Warning|Error) ' >/dev/null; then
+                echo "::error file=$file::bicep lint warning/error in $file"
+                fail=1
+              fi
+            done
           done
-          echo "all bicepparam files compiled clean"
+          if [ "$fail" -ne 0 ]; then exit 1; fi
+          echo "All bicepparam files compiled clean (zero warnings)."

--- a/infra/bicep/azure.bicep
+++ b/infra/bicep/azure.bicep
@@ -79,10 +79,12 @@ module containerAppsEnv 'modules/container-apps-environment.bicep' = {
   params: {
     name:                    caeName
     location:                location
-    logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
-    logAnalyticsCustomerId:  logAnalytics.outputs.customerId
+    logAnalyticsWorkspaceName: lawName
     tags:                    tags
   }
+  dependsOn: [
+    logAnalytics
+  ]
 }
 
 module acaStack 'modules/aca-stack.bicep' = {
@@ -103,9 +105,12 @@ module acaStack 'modules/aca-stack.bicep' = {
 module kvRbac 'modules/key-vault-rbac.bicep' = {
   name:  'kv-rbac'
   params: {
-    keyVaultName: keyVault.outputs.keyVaultName
+    keyVaultName: kvName
     principalIds: acaStack.outputs.principalIds
   }
+  dependsOn: [
+    keyVault
+  ]
 }
 
 @description('Resource group containing every FTGO resource for this environment.')

--- a/infra/bicep/bicepconfig.json
+++ b/infra/bicep/bicepconfig.json
@@ -2,5 +2,51 @@
   "extensions": {
     "graphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.2.0-preview"
   },
-  "implicitExtensions": []
+  "implicitExtensions": [],
+  "analyzers": {
+    "core": {
+      "enabled": true,
+      "verbose": true,
+      "rules": {
+        "adminusername-should-not-be-literal": { "level": "error" },
+        "artifacts-parameters": { "level": "warning" },
+        "decompiler-cleanup": { "level": "error" },
+        "explicit-values-for-loc-params": { "level": "warning" },
+        "max-asserts": { "level": "warning" },
+        "max-outputs": { "level": "warning" },
+        "max-params": { "level": "warning" },
+        "max-resources": { "level": "warning" },
+        "max-variables": { "level": "warning" },
+        "nested-deployment-template-scoping": { "level": "error" },
+        "no-conflicting-metadata": { "level": "error" },
+        "no-deployments-resources": { "level": "warning" },
+        "no-hardcoded-env-urls": { "level": "error" },
+        "no-hardcoded-location": { "level": "error" },
+        "no-loc-expr-outside-params": { "level": "error" },
+        "no-unnecessary-dependson": { "level": "warning" },
+        "no-unused-existing-resources": { "level": "warning" },
+        "no-unused-imports": { "level": "warning" },
+        "no-unused-params": { "level": "warning" },
+        "no-unused-vars": { "level": "warning" },
+        "outputs-should-not-contain-secrets": { "level": "error" },
+        "prefer-interpolation": { "level": "warning" },
+        "prefer-unquoted-property-names": { "level": "warning" },
+        "protect-commandtoexecute-secrets": { "level": "error" },
+        "secure-parameter-default": { "level": "error" },
+        "secure-params-in-nested-deploy": { "level": "error" },
+        "secure-secrets-in-params": { "level": "error" },
+        "simplify-interpolation": { "level": "warning" },
+        "simplify-json-null": { "level": "warning" },
+        "use-parent-property": { "level": "warning" },
+        "use-recent-api-versions": { "level": "off" },
+        "use-resource-id-functions": { "level": "warning" },
+        "use-resource-symbol-reference": { "level": "warning" },
+        "use-safe-access": { "level": "warning" },
+        "use-secure-value-for-secure-inputs": { "level": "error" },
+        "use-stable-resource-identifiers": { "level": "warning" },
+        "use-stable-vm-image": { "level": "warning" },
+        "what-if-short-circuiting": { "level": "warning" }
+      }
+    }
+  }
 }

--- a/infra/bicep/modules/container-apps-environment.bicep
+++ b/infra/bicep/modules/container-apps-environment.bicep
@@ -9,17 +9,14 @@ param name string
 @description('Azure region for the environment.')
 param location string
 
-@description('Resource ID of the Log Analytics workspace receiving container app logs.')
-param logAnalyticsWorkspaceId string
-
-@description('Customer ID (workspace GUID) of the Log Analytics workspace.')
-param logAnalyticsCustomerId string
+@description('Name of the Log Analytics workspace receiving container app logs (design-time-known to keep what-if precise).')
+param logAnalyticsWorkspaceName string
 
 @description('Tags applied to the environment.')
 param tags object = {}
 
 resource law 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
-  name: last(split(logAnalyticsWorkspaceId, '/'))
+  name: logAnalyticsWorkspaceName
 }
 
 resource cae 'Microsoft.App/managedEnvironments@2024-10-02-preview' = {
@@ -30,7 +27,7 @@ resource cae 'Microsoft.App/managedEnvironments@2024-10-02-preview' = {
     appLogsConfiguration: {
       destination: 'log-analytics'
       logAnalyticsConfiguration: {
-        customerId: logAnalyticsCustomerId
+        customerId: law.properties.customerId
         sharedKey:  law.listKeys().primarySharedKey
       }
     }


### PR DESCRIPTION
## Why

`infra/bicep/bicepconfig.json` only declared the Microsoft Graph extension — **no analyzer rules at all**. CI ran `az bicep build` (which silently emits warnings) but never failed on them. So new modules could ship with secret-in-output bugs, hard-coded locations, what-if short-circuits, or unused params, and CI wouldn't notice.

## What

### bicepconfig.json
Enabled ~30 core analyzer rules. Security/correctness as **error**, style/hygiene as **warning**:

| Severity | Notable rules |
|---|---|
| error | `no-hardcoded-location`, `no-hardcoded-env-urls`, `outputs-should-not-contain-secrets`, `secure-secrets-in-params`, `use-secure-value-for-secure-inputs`, `secure-parameter-default` |
| warning | `what-if-short-circuiting`, `no-unused-params/vars/imports`, `prefer-interpolation`, `simplify-interpolation`, `use-safe-access`, `use-resource-symbol-reference` |

### Two real findings fixed
`what-if-short-circuiting` flagged two modules taking deployment-runtime values that are design-time known:

1. `modules/container-apps-environment.bicep` — was taking `logAnalyticsWorkspaceId` (runtime) and `logAnalyticsCustomerId` (runtime). Now takes `logAnalyticsWorkspaceName` (design-time) and reads `.properties.customerId` from an `existing` lookup. Explicit `dependsOn: [logAnalytics]` preserves ordering.
2. `modules/key-vault-rbac.bicep` — was taking `keyVault.outputs.keyVaultName` (runtime). Now takes the design-time `kvName` var + `dependsOn: [keyVault]`.

Both make `az deployment what-if` more precise (no short-circuit message in preview).

### CI hardening
`bicep-lint` job now:
- Loops over **all** templates including every `modules/*.bicep` (was just main + azure + bootstrap)
- Greps stderr for `Warning`/`Error` lines and fails CI on any (vanilla `az bicep build` only fails on errors)
- `build-params` loop now also includes `azure.{env}.bicepparam` (was missing)

## Verified locally

```
$ for f in infra/bicep/main.bicep infra/bicep/azure.bicep infra/bicep/bootstrap.bicep infra/bicep/modules/*.bicep; do
    az bicep build --file "$f" --stdout 2>&1 >/dev/null | grep -E 'Warning|Error' || true
  done
# (no output → zero warnings)

$ AZURE_TENANT_ID=00000000-0000-0000-0000-000000000000 GH_OWNER=mghabin GH_REPO=entra-auth-patterns-dotnet \
    bash -c 'for f in infra/bicep/*.bicepparam; do az bicep build-params --file "$f" --stdout >/dev/null; done'
# (clean)
```

## Behaviour

No deploy semantics change — only lint enforcement. The 2 module fixes preserve identical resource topology; just routes the same data through a more analyzable path.