### PR TITLE
feat(bicep): KV+LAW diagnostic settings + tag enrichment

### DIFF
--- a/infra/bicep/azure.bicep
+++ b/infra/bicep/azure.bicep
@@ -18,11 +18,13 @@ param imageTag string = 'latest'
 @description('Container registry base. Public images: anonymous pull, no registry credentials needed.')
 param containerRegistry string = 'ghcr.io/mghabin'
 
-@description('Tags applied to every resource.')
+@description('Tags applied to every resource. Defaults include the standard env/workload/managedBy/repo set; callers can override per-deploy.')
 param tags object = {
   environment: environmentName
   workload:    'ftgo'
   managedBy:   'bicep'
+  repo:        'mghabin/entra-auth-patterns-dotnet'
+  costCenter:  'sample-${environmentName}'
 }
 
 @description('Resolved Entra wiring (tenantId, app reg appIds, kitchen-worker MI clientId, downstream FQDNs). Empty `{}` on cold deploy → apps fall back to appsettings.json placeholders. Populated by scripts/provision-apps.sh after Entra app regs and worker MI are known.')
@@ -67,10 +69,11 @@ module appInsights 'modules/app-insights.bicep' = {
 module keyVault 'modules/key-vault.bicep' = {
   name:  'kv'
   params: {
-    name:     kvName
-    location: location
-    tenantId: subscription().tenantId
-    tags:     tags
+    name:                    kvName
+    location:                location
+    tenantId:                subscription().tenantId
+    logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
+    tags:                    tags
   }
 }
 

--- a/infra/bicep/bootstrap.bicep
+++ b/infra/bicep/bootstrap.bicep
@@ -41,6 +41,8 @@ var tags = {
   environment: environmentName
   workload:    'ftgo'
   managedBy:   'bicep'
+  repo:        '${githubOwner}/${githubRepo}'
+  costCenter:  'sample-${environmentName}'
   purpose:     'cd-bootstrap'
 }
 

--- a/infra/bicep/modules/key-vault.bicep
+++ b/infra/bicep/modules/key-vault.bicep
@@ -14,6 +14,9 @@ param location string
 @description('Tenant id that owns the vault (used to scope RBAC role assignments).')
 param tenantId string
 
+@description('Resource ID of the Log Analytics workspace receiving the vault audit log + AllMetrics.')
+param logAnalyticsWorkspaceId string
+
 @description('Tags applied to the vault.')
 param tags object = {}
 
@@ -36,6 +39,29 @@ resource kv 'Microsoft.KeyVault/vaults@2024-04-01-preview' = {
       defaultAction: 'Allow'
       bypass:        'AzureServices'
     }
+  }
+}
+
+// AuditEvent → Log Analytics. Captures every secret/key/cert read & policy
+// change. Required for any production audit trail; cheap on a dev workload
+// where no secrets are actually read.
+resource kvDiag 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name:  'to-law'
+  scope: kv
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      {
+        categoryGroup: 'audit'
+        enabled:       true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled:  true
+      }
+    ]
   }
 }
 

--- a/infra/bicep/modules/log-analytics.bicep
+++ b/infra/bicep/modules/log-analytics.bicep
@@ -32,6 +32,29 @@ resource law 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   }
 }
 
+// Self-monitor: ship the workspace's own audit log (who queried what) into
+// itself. Audit goes into LAQueryLogs table — useful for "who ran an
+// expensive query" investigations and required for compliance audits.
+resource lawDiag 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name:  'self-audit'
+  scope: law
+  properties: {
+    workspaceId: law.id
+    logs: [
+      {
+        categoryGroup: 'audit'
+        enabled:       true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled:  true
+      }
+    ]
+  }
+}
+
 @description('Resource ID of the workspace (used by App Insights and Container Apps Environment).')
 output workspaceId string = law.id
 


### PR DESCRIPTION
## Why

The eng guide is silent on platform observability + tag hygiene, but every prod
deployment needs both. Closes two industry-best-practice gaps from the IaC audit:

- **No audit trail on Key Vault.** Reads/writes/policy changes were invisible.
- **Inconsistent tagging.** Cost Management couldn't filter by repo or cost center.

## What

- `modules/key-vault.bicep`: required `logAnalyticsWorkspaceId` param; ships
  `audit` categoryGroup + AllMetrics into LAW.
- `modules/log-analytics.bicep`: self-audit diagnostic setting (workspace as its
  own destination — LAQueryLogs into itself).
- `azure.bicep` + `bootstrap.bicep`: tags object now carries `repo` and
  `costCenter` alongside the existing env/workload/managedBy.

## Verification

`az bicep build` on every template under strict bicepconfig — zero warnings,
zero errors.

## Risk

Low. New diagnostic settings are additive resources; no existing resource is
mutated. Tag changes are metadata-only.