### PR TITLE
chore(deps): track docker base images in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,13 @@ updates:
       actions:
         patterns:
           - "*"
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds the `docker` ecosystem to `.github/dependabot.yml`. Grouped so all base-image bumps land in a single weekly PR. Closes the silent-staleness gap on the .NET runtime/SDK base images.