### PR TITLE
feat(bicep): env-aware Key Vault soft-delete + purge protection

### DIFF
--- a/infra/bicep/azure.bicep
+++ b/infra/bicep/azure.bicep
@@ -30,6 +30,14 @@ param tags object = {
 @description('Resolved Entra wiring (tenantId, app reg appIds, kitchen-worker MI clientId, downstream FQDNs). Empty `{}` on cold deploy → apps fall back to appsettings.json placeholders. Populated by scripts/provision-apps.sh after Entra app regs and worker MI are known.')
 param entraConfig object = {}
 
+@description('Key Vault soft-delete retention in days. Non-prod stays at 7 so churned envs free their globally-unique vault names quickly; prod sits at 90 to align with typical compliance/recovery windows.')
+@minValue(7)
+@maxValue(90)
+param keyVaultSoftDeleteRetentionInDays int = environmentName == 'prod' ? 90 : 7
+
+@description('Permanently lock the vault against early purge. Required in prod; off in non-prod so the resource can be deleted without waiting out the retention clock. NOTE: irreversible once set to true.')
+param keyVaultEnablePurgeProtection bool = environmentName == 'prod'
+
 // Region → short token folded into resource names. Falls back to first 3 chars for unmapped regions.
 var regionShortMap = {
   eastus:       'eus'
@@ -69,11 +77,13 @@ module appInsights 'modules/app-insights.bicep' = {
 module keyVault 'modules/key-vault.bicep' = {
   name:  'kv'
   params: {
-    name:                    kvName
-    location:                location
-    tenantId:                subscription().tenantId
-    logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
-    tags:                    tags
+    name:                       kvName
+    location:                   location
+    tenantId:                   subscription().tenantId
+    logAnalyticsWorkspaceId:    logAnalytics.outputs.workspaceId
+    tags:                       tags
+    softDeleteRetentionInDays:  keyVaultSoftDeleteRetentionInDays
+    enablePurgeProtection:      keyVaultEnablePurgeProtection
   }
 }
 

--- a/infra/bicep/modules/key-vault.bicep
+++ b/infra/bicep/modules/key-vault.bicep
@@ -1,5 +1,5 @@
 metadata name = 'key-vault'
-metadata description = 'Standard-SKU Key Vault with RBAC authorization, soft-delete on, 7-day retention. Public network access enabled for ACA reachability.'
+metadata description = 'Standard-SKU Key Vault with RBAC authorization, soft-delete on. Soft-delete retention is parameterized so non-prod can recover quickly (7d) and prod meets compliance windows (90d). Public network access enabled for ACA reachability.'
 
 extension az
 
@@ -20,6 +20,14 @@ param logAnalyticsWorkspaceId string
 @description('Tags applied to the vault.')
 param tags object = {}
 
+@description('Soft-delete retention in days. Microsoft minimum is 7, maximum is 90. Prod should sit at 90 to meet typical audit/recovery windows; non-prod stays at 7 to free names quickly.')
+@minValue(7)
+@maxValue(90)
+param softDeleteRetentionInDays int = 7
+
+@description('When true, the vault cannot be purged before retention expires (irreversible). Required for prod compliance; off in non-prod so churned environments do not pile up undeletable vaults.')
+param enablePurgeProtection bool = false
+
 resource kv 'Microsoft.KeyVault/vaults@2024-04-01-preview' = {
   name:     name
   location: location
@@ -32,8 +40,8 @@ resource kv 'Microsoft.KeyVault/vaults@2024-04-01-preview' = {
     }
     enableRbacAuthorization:   true
     enableSoftDelete:          true
-    softDeleteRetentionInDays: 7
-    enablePurgeProtection:     null
+    softDeleteRetentionInDays: softDeleteRetentionInDays
+    enablePurgeProtection:     enablePurgeProtection ? true : null
     publicNetworkAccess:       'Enabled'
     networkAcls: {
       defaultAction: 'Allow'


### PR DESCRIPTION
## Why

Single hard-coded `softDeleteRetentionInDays: 7` and `enablePurgeProtection: null` in `modules/key-vault.bicep` is wrong for prod (compliance wants 90+ days and an irreversible lock) and wrong for non-prod (a 7-day no-purge default is correct, but it shouldn't be hard-coded).

## What

- New params in `azure.bicep`:
  - `keyVaultSoftDeleteRetentionInDays` (default: `environmentName == 'prod' ? 90 : 7`)
  - `keyVaultEnablePurgeProtection` (default: `environmentName == 'prod'`)
- Threaded into `modules/key-vault.bicep`, which now exposes them as min/max-validated params.
- Purge protection uses `? true : null` — never sets `false`, since the API treats true as immutable.

## Verification

`az bicep build` on every template under strict bicepconfig — zero warnings, zero errors.

## Risk

Low for new deploys. **For existing dev/ppe vaults**: defaults match what's already there (7d, no purge). **For prod's first deploy**: irreversible — confirm with stakeholders before rolling out. The param is overridable via bicepparam so an opt-out is one line.