### PR TITLE
feat(cd): SBOM + signed build-provenance attestations

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -89,12 +90,17 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push ${{ matrix.project }}
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           push: true
-          provenance: false
+          # SLSA build-provenance attestation — written into the registry alongside the image.
+          # Verifiable with `cosign verify-attestation` or `gh attestation verify`.
+          provenance: mode=max
+          # SBOM in SPDX format, also pushed to the registry.
+          sbom: true
           build-args: |
             PROJECT=${{ matrix.project }}
             BUILD_GIT_SHA=${{ github.sha }}
@@ -105,6 +111,16 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/ftgo-${{ steps.meta.outputs.SHORT_NAME }}:latest
           cache-from: type=gha,scope=ftgo-${{ steps.meta.outputs.SHORT_NAME }}
           cache-to: type=gha,scope=ftgo-${{ steps.meta.outputs.SHORT_NAME }},mode=max
+
+      # Cryptographically signed provenance attestation, pushed to the GitHub
+      # attestation store + Sigstore transparency log. Verifies who built the
+      # image, on which commit, with which workflow.
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/ftgo-${{ steps.meta.outputs.SHORT_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
   resolve-image-tag:
     # Resolve image tag once and pass it to all downstream env deploys.


### PR DESCRIPTION
## Why

Eng guide §12 (CI/CD) requires SBOM + container attestation as supply-chain must-haves. We were running with neither: `provenance: false` and no SBOM step.

## What

- `docker/build-push-action@v6`: `provenance: mode=max` + `sbom: true`. SPDX SBOM and BuildKit attestation pushed to GHCR alongside each image.
- `actions/attest-build-provenance@v2` step: signs an SLSA provenance statement with a short-lived OIDC identity, records it in Sigstore Rekor, pushes to the registry attestation store. Verifiable via `gh attestation verify`.
- New `attestations: write` permission on `build-images`.

## Risk

Low. Adds ~30s per image to the build matrix. No deploy-path code touched. If the attest step fails, the image still builds and pushes (it's a separate step that runs after); we can choose to make it a blocking gate later via job-level `if`.

## Followups

- Verify in deploy-env.yml before pulling: `gh attestation verify oci://...` as a deploy-time check.
- Wire cosign verification into a Kyverno policy when we eventually run on AKS.