### PR TITLE
chore(governance): CODEOWNERS + PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS — auto-request review on touched paths.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Order matters: the LAST matching pattern wins for a given file.
+
+# Global default reviewer.
+* @mghabin
+
+# Infrastructure-as-code (Bicep + bootstrap scripts) — handle with extra care
+# because changes ripple across every environment.
+/infra/                 @mghabin
+/scripts/               @mghabin
+/.github/workflows/     @mghabin
+/.github/dependabot.yml @mghabin
+/.github/CODEOWNERS     @mghabin
+
+# Auth/identity surface — every change here is a potential security event.
+/src/Ftgo.Auth/         @mghabin
+/docs/credential-patterns/ @mghabin
+/SECURITY.md            @mghabin
+
+# Engineering-guide-style root config files — TreatWarningsAsErrors and lock
+# files in particular have wide blast radius if loosened.
+/Directory.Build.props  @mghabin
+/Directory.Packages.props @mghabin
+/global.json            @mghabin
+/Dockerfile             @mghabin

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+<!-- Keep this short. Reviewers should be able to grok the PR in <60s. -->
+
+## Why
+
+<!-- One paragraph: what problem does this solve? Cite the issue/finding/audit
+that motivated it if applicable. -->
+
+## What
+
+<!-- Bullet list of the actual changes. Mention any new dependencies, new env
+vars, new infra resources, or breaking changes. -->
+
+-
+
+## Verification
+
+<!-- How did you confirm it works?
+     - tests added/updated  : …
+     - manual check         : …
+     - lint/build clean     : …
+     - cloud deploy verified: env=…  -->
+
+## Risk & rollback
+
+<!-- Worst case if this regresses, and how to revert. For infra changes, note
+whether the change is reversible (e.g. KV purge protection is NOT). -->
+
+---
+
+### Checklist
+
+- [ ] CI is green (`build-test`, `bicep-lint`, `CodeQL`, `dependency-review`)
+- [ ] No new warnings (project-level `TreatWarningsAsErrors` will fail otherwise)
+- [ ] Docs updated if public surface or operator workflow changed
+- [ ] No secrets, tokens, or PII in the diff (run `git diff --stat`)
+- [ ] If infra: previewed with `WHAT_IF=1 ./scripts/provision-apps.sh ENV=…` (or `az deployment ... what-if`) before merge


### PR DESCRIPTION
Adds:
- `.github/CODEOWNERS` — global default + heavier weight on infra/auth/security paths.
- `.github/pull_request_template.md` — Why / What / Verification / Risk + checklist that mirrors the eng-guide gates and the new WHAT_IF preview habit.

Pure docs/governance. No code touched, no CI behavior changes.