### PR TITLE
feat(cd): post-deploy /health/live smoke test

### DIFF
--- a/.github/workflows/deploy-env.yml
+++ b/.github/workflows/deploy-env.yml
@@ -196,3 +196,25 @@ jobs:
             echo ""
             echo "_Entra app regs are provisioned out-of-band via_ \`scripts/provision-apps.sh ENV=${ENV_NAME}\`_, which writes the_ \`ENTRA_CONFIG_JSON\` _GitHub env var consumed here._"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Smoke-test /health/live
+        env:
+          AGW_FQDN: ${{ steps.deploy.outputs.apigateway_fqdn }}
+        run: |
+          set -euo pipefail
+          URL="https://${AGW_FQDN}/health/live"
+          echo "Polling ${URL} (60s timeout)…"
+          # ACA cold-start can take ~30s after a fresh image; poll for up to 60s.
+          # /health/live is checked instead of /health/ready because the BFF's
+          # readiness depends on Entra config which is provisioned out-of-band
+          # (would false-fail on a cold env).
+          for i in $(seq 1 12); do
+            if curl --fail --silent --show-error --max-time 5 "$URL" >/dev/null; then
+              echo "✓ ${URL} returned 200 (attempt ${i})"
+              exit 0
+            fi
+            echo "  attempt ${i} — not ready yet, sleeping 5s"
+            sleep 5
+          done
+          echo "✗ ${URL} did not return 200 within 60s"
+          exit 1


### PR DESCRIPTION
## Why

ARM tells us "the container app's revision is provisioned" but says nothing about whether the .NET process inside actually started. A bad config or analyzer-injected init failure produces a green CD with a dead container.

## What

`deploy-env.yml` polls `https://${apigateway_fqdn}/health/live` for up to 60s after the deploy step. First 200 → step succeeds. No 200 in 60s → workflow fails.

`/health/live` is used (not `/ready`) because the BFF's readiness depends on Entra config that's provisioned out-of-band; `ready` would false-fail on cold envs.

## Risk

Low. Pure additive step at the end of the job. Worst case: a flaky 60s window fails the deploy, the operator re-runs.

## Followups

After Entra wiring is also automated (i.e. ENTRA_CONFIG_JSON is always present), switch to `/health/ready` to catch real readiness regressions.