### PR TITLE
chore(workflows): normalize action versions

### DIFF
--- a/.github/workflows/cd-cleanup.yml
+++ b/.github/workflows/cd-cleanup.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         env: [dev, ppe]
     steps:
-      - uses: azure/login@v2
+      - uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       imageTag: ${{ steps.meta.outputs.imageTag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Compute image metadata
         id: meta

--- a/.github/workflows/deploy-env.yml
+++ b/.github/workflows/deploy-env.yml
@@ -70,7 +70,7 @@ jobs:
       scalar_url: ${{ steps.deploy.outputs.scalar_url }}
       apigateway_redirect: ${{ steps.deploy.outputs.apigateway_redirect }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Resolve image tag
         id: tag
@@ -84,7 +84,7 @@ jobs:
           fi
           echo "imageTag=${TAG}" >> "$GITHUB_OUTPUT"
 
-      - uses: azure/login@v2
+      - uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
Cosmetic but real: `actions/checkout` and `azure/login` were running on different majors across workflows. Standardize on the latest in-repo (`@v6` and `@v3`). Dependabot's existing actions group keeps them current going forward.