### PR TITLE
fix(cd-cleanup): per-matrix-env GitHub Environment

### DIFF
--- a/.github/workflows/cd-cleanup.yml
+++ b/.github/workflows/cd-cleanup.yml
@@ -14,7 +14,12 @@ permissions:
 jobs:
   scale-down:
     runs-on: ubuntu-latest
-    environment: dev
+    # Per-matrix-env GitHub Environment so each iteration uses its own
+    # AZURE_CLIENT_ID / AZURE_SUBSCRIPTION_ID vars + secrets. Without this,
+    # both dev and ppe would resolve from whatever single environment was
+    # hard-coded here, defeating the per-env credential separation that
+    # the rest of CD relies on.
+    environment: ${{ matrix.env }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Real bug. The matrix iterates [dev, ppe] but `environment: dev` was hard-coded → ppe iteration runs with dev's federated credential. Either silently no-ops or, in a worse permission shape, applies dev's identity to a ppe RG. Standard pattern: `environment: ${{ matrix.env }}`.