### PR TITLE
fix(infra): plumb LOCATION end-to-end (followup to #46)

### DIFF
--- a/.github/workflows/deploy-env.yml
+++ b/.github/workflows/deploy-env.yml
@@ -65,6 +65,9 @@ jobs:
       RG: rg-ftgo-${{ inputs.environment }}-${{ inputs.location }}
       APP: ftgo-${{ inputs.environment }}-apigateway-${{ inputs.region_short }}
       BICEPPARAM: infra/bicep/azure.${{ inputs.environment }}.bicepparam
+      # Consumed by azure.${env}.bicepparam's `readEnvironmentVariable('LOCATION', 'eastus')`
+      # so the bicep `location` param matches the RG suffix derived above.
+      LOCATION: ${{ inputs.location }}
     outputs:
       apigateway_fqdn: ${{ steps.deploy.outputs.apigateway_fqdn }}
       scalar_url: ${{ steps.deploy.outputs.scalar_url }}

--- a/infra/bicep/azure.dev.bicepparam
+++ b/infra/bicep/azure.dev.bicepparam
@@ -8,6 +8,6 @@
 using 'azure.bicep'
 
 param environmentName   = 'dev'
-param location          = 'eastus'
+param location          = readEnvironmentVariable('LOCATION', 'eastus')
 param imageTag          = readEnvironmentVariable('IMAGE_TAG',          'latest')
 param containerRegistry = readEnvironmentVariable('CONTAINER_REGISTRY', 'ghcr.io/mghabin')

--- a/infra/bicep/azure.ppe.bicepparam
+++ b/infra/bicep/azure.ppe.bicepparam
@@ -8,6 +8,6 @@
 using 'azure.bicep'
 
 param environmentName   = 'ppe'
-param location          = 'eastus'
+param location          = readEnvironmentVariable('LOCATION', 'eastus')
 param imageTag          = readEnvironmentVariable('IMAGE_TAG',          'latest')
 param containerRegistry = readEnvironmentVariable('CONTAINER_REGISTRY', 'ghcr.io/mghabin')

--- a/infra/bicep/azure.prod.bicepparam
+++ b/infra/bicep/azure.prod.bicepparam
@@ -8,6 +8,6 @@
 using 'azure.bicep'
 
 param environmentName   = 'prod'
-param location          = 'eastus'
+param location          = readEnvironmentVariable('LOCATION', 'eastus')
 param imageTag          = readEnvironmentVariable('IMAGE_TAG',          'latest')
 param containerRegistry = readEnvironmentVariable('CONTAINER_REGISTRY', 'ghcr.io/mghabin')

--- a/scripts/provision-apps.sh
+++ b/scripts/provision-apps.sh
@@ -63,7 +63,9 @@ done
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
-LOCATION="${LOCATION:-eastus}"
+# Export LOCATION so azure.${ENV}.bicepparam's `readEnvironmentVariable('LOCATION', 'eastus')`
+# picks it up — keeps the script's RG/app-name derivation in lock-step with bicep.
+export LOCATION="${LOCATION:-eastus}"
 case "$LOCATION" in
   eastus)      REGION_SHORT="eus" ;;
   eastus2)     REGION_SHORT="eus2" ;;


### PR DESCRIPTION
## Why

Critique of the IaC PR train caught that PR #46 changed only the **script-side** RG/app-name derivation but left `azure.${env}.bicepparam` hard-coded to `eastus`. Result on a non-default LOCATION:

  - script computes `rg-ftgo-dev-westeurope` and waits for `*-weu` apps;
  - bicep deploys to `location='eastus'` and creates `*-eus` apps in the wrong RG.

Half-state, hard to diagnose, very easy to ship if someone uses the new `LOCATION` knob.

## What

- `scripts/provision-apps.sh`: `export LOCATION` (was a plain var).
- `infra/bicep/azure.{dev,ppe,prod}.bicepparam`: `location = readEnvironmentVariable('LOCATION', 'eastus')`. Defaults preserve current behavior.
- `.github/workflows/deploy-env.yml`: job env now sets `LOCATION: ${{ inputs.location }}` so the bicepparam picks it up in CD.

## Verification

- `az bicep build` clean on every template.
- `LOCATION=westeurope az bicep build-params` clean on every `azure.*.bicepparam`.
- `bash -n scripts/provision-apps.sh` clean.

## Risk

Zero for default callers (no env var → bicepparam falls back to eastus, same as before).