### PR TITLE
feat(infra): CanNotDelete lock on prod resource group

### DIFF
--- a/.github/workflows/deploy-env.yml
+++ b/.github/workflows/deploy-env.yml
@@ -203,12 +203,14 @@ jobs:
         run: |
           set -euo pipefail
           URL="https://${AGW_FQDN}/health/live"
-          echo "Polling ${URL} (60s timeout)…"
-          # ACA cold-start can take ~30s after a fresh image; poll for up to 60s.
+          echo "Polling ${URL} (180s timeout)…"
+          # ACA cold-start (image pull + container init + ASP.NET warmup) can
+          # exceed 60s after a fresh image push; poll for up to 180s to avoid
+          # flaky CD failures that mask actual deploy success.
           # /health/live is checked instead of /health/ready because the BFF's
           # readiness depends on Entra config which is provisioned out-of-band
           # (would false-fail on a cold env).
-          for i in $(seq 1 12); do
+          for i in $(seq 1 36); do
             if curl --fail --silent --show-error --max-time 5 "$URL" >/dev/null; then
               echo "✓ ${URL} returned 200 (attempt ${i})"
               exit 0
@@ -216,5 +218,5 @@ jobs:
             echo "  attempt ${i} — not ready yet, sleeping 5s"
             sleep 5
           done
-          echo "✗ ${URL} did not return 200 within 60s"
+          echo "✗ ${URL} did not return 200 within 180s"
           exit 1

--- a/infra/bicep/azure.bicep
+++ b/infra/bicep/azure.bicep
@@ -126,6 +126,19 @@ module kvRbac 'modules/key-vault-rbac.bicep' = {
   ]
 }
 
+// Prod safety net: prevent accidental `az group delete` / portal-delete of the
+// entire RG. CanNotDelete still lets ARM perform in-place updates but blocks
+// destructive operations until the lock is removed. Dev/PPE intentionally have
+// no lock so cd-cleanup and tear-down flows stay simple.
+resource rgDeleteLock 'Microsoft.Authorization/locks@2020-05-01' = if (environmentName == 'prod') {
+  name: 'ftgo-prod-rg-delete-lock'
+  scope: resourceGroup()
+  properties: {
+    level: 'CanNotDelete'
+    notes: 'Prod RG delete protection. Remove via `az lock delete` only as part of an approved teardown.'
+  }
+}
+
 @description('Resource group containing every FTGO resource for this environment.')
 output resourceGroupName string = resourceGroup().name
 


### PR DESCRIPTION
Conditional `Microsoft.Authorization/locks` deployed only when `environmentName == 'prod'`. Prevents accidental teardown of the prod RG; dev/ppe unaffected.