### PR TITLE
chore(governance): branch protection as code

### DIFF
--- a/.github/branch-protection/main.json
+++ b/.github/branch-protection/main.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "Declarative branch-protection config for refs/heads/main. Apply via the apply-branch-protection workflow (manual dispatch). This file is the source of truth — drift means update the file + re-apply, not click in the UI.",
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "build-test",
+      "bicep-lint",
+      "dependency-review",
+      "Analyze (csharp)",
+      "Analyze (actions)"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}

--- a/.github/branch-protection/main.json
+++ b/.github/branch-protection/main.json
@@ -7,7 +7,9 @@
       "bicep-lint",
       "dependency-review",
       "Analyze (csharp)",
-      "Analyze (actions)"
+      "Analyze (actions)",
+      "actionlint",
+      "gitleaks"
     ]
   },
   "enforce_admins": true,

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,9 +1,12 @@
 # Branch protection lives in code, not in the GitHub UI. The committed JSON
-# under .github/branch-protection/ is the source of truth. Apply it by
-# dispatching this workflow; drift is reported by the nightly diff job.
+# under .github/branch-protection/ is the source of truth.
 #
-# Required PAT scope is repo (or admin:repo for protected branches). The
-# default GITHUB_TOKEN is sufficient because the workflow runs in this repo.
+# Auth: branch-protection writes are NOT possible with the default
+# GITHUB_TOKEN — the API requires repo-administration permission, which the
+# automatic token cannot grant. Set a fine-grained PAT (or GitHub App
+# installation token) with "Administration: Read and write" as a repo
+# secret named BRANCH_PROTECTION_TOKEN. The drift job needs the same
+# scope (read) to fetch live config.
 name: branch-protection
 
 on:
@@ -24,18 +27,19 @@ jobs:
   apply:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      administration: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Apply branch protection from JSON
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}
           BRANCH:  ${{ inputs.branch }}
         run: |
           set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::Secret BRANCH_PROTECTION_TOKEN is not set. See workflow header for required scopes."
+            exit 1
+          fi
           FILE=".github/branch-protection/${BRANCH}.json"
           if [[ ! -f "$FILE" ]]; then
             echo "::error::No protection config found at $FILE"
@@ -50,19 +54,19 @@ jobs:
             --input -
 
   drift:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      administration: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Diff live branch protection vs committed JSON
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}
         run: |
           set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::Secret BRANCH_PROTECTION_TOKEN is not set; drift job cannot read protection config."
+            exit 1
+          fi
           shopt -s nullglob
           configs=(.github/branch-protection/*.json)
           if [[ ${#configs[@]} -eq 0 ]]; then
@@ -73,21 +77,37 @@ jobs:
           for f in "${configs[@]}"; do
             branch=$(basename "$f" .json)
             echo "::group::Diffing refs/heads/${branch}"
-            expected=$(jq 'del(._comment)' "$f")
-            # Live API returns extra read-only fields; project to the keys we manage.
+            # Project both sides to the same shape, sort contexts so ordering
+            # doesn't cause false drift, and normalize with `jq -S` for diff.
+            expected=$(jq 'del(._comment)
+              | .required_status_checks.contexts |= (. // [] | sort)
+            ' "$f")
             live=$(gh api "repos/${{ github.repository }}/branches/${branch}/protection" 2>/dev/null \
               | jq '{
-                  required_status_checks: (.required_status_checks // null) | if . then {strict: .strict, contexts: .contexts} else null end,
-                  enforce_admins: (.enforce_admins.enabled // false),
-                  required_pull_request_reviews: (.required_pull_request_reviews // null) | if . then {dismiss_stale_reviews, require_code_owner_reviews, required_approving_review_count, require_last_push_approval} else null end,
+                  required_status_checks: (
+                    if .required_status_checks then
+                      {strict: .required_status_checks.strict, contexts: (.required_status_checks.contexts // [] | sort)}
+                    else null end
+                  ),
+                  enforce_admins: ((.enforce_admins.enabled) // false),
+                  required_pull_request_reviews: (
+                    if .required_pull_request_reviews then
+                      {
+                        dismiss_stale_reviews: .required_pull_request_reviews.dismiss_stale_reviews,
+                        require_code_owner_reviews: .required_pull_request_reviews.require_code_owner_reviews,
+                        required_approving_review_count: .required_pull_request_reviews.required_approving_review_count,
+                        require_last_push_approval: .required_pull_request_reviews.require_last_push_approval
+                      }
+                    else null end
+                  ),
                   restrictions: null,
-                  required_linear_history: (.required_linear_history.enabled // false),
-                  allow_force_pushes: (.allow_force_pushes.enabled // false),
-                  allow_deletions: (.allow_deletions.enabled // false),
-                  block_creations: (.block_creations.enabled // false),
-                  required_conversation_resolution: (.required_conversation_resolution.enabled // false),
-                  lock_branch: (.lock_branch.enabled // false),
-                  allow_fork_syncing: (.allow_fork_syncing.enabled // false)
+                  required_linear_history: ((.required_linear_history.enabled) // false),
+                  allow_force_pushes: ((.allow_force_pushes.enabled) // false),
+                  allow_deletions: ((.allow_deletions.enabled) // false),
+                  block_creations: ((.block_creations.enabled) // false),
+                  required_conversation_resolution: ((.required_conversation_resolution.enabled) // false),
+                  lock_branch: ((.lock_branch.enabled) // false),
+                  allow_fork_syncing: ((.allow_fork_syncing.enabled) // false)
                 }')
             expected_norm=$(echo "$expected" | jq -S .)
             live_norm=$(echo "$live"     | jq -S .)

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,106 @@
+# Branch protection lives in code, not in the GitHub UI. The committed JSON
+# under .github/branch-protection/ is the source of truth. Apply it by
+# dispatching this workflow; drift is reported by the nightly diff job.
+#
+# Required PAT scope is repo (or admin:repo for protected branches). The
+# default GITHUB_TOKEN is sufficient because the workflow runs in this repo.
+name: branch-protection
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch ref to protect (must have a matching JSON under .github/branch-protection/)'
+        type: string
+        default: main
+  schedule:
+    # Drift report only — never auto-applies.
+    - cron: '0 4 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      administration: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Apply branch protection from JSON
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH:  ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          FILE=".github/branch-protection/${BRANCH}.json"
+          if [[ ! -f "$FILE" ]]; then
+            echo "::error::No protection config found at $FILE"
+            exit 1
+          fi
+          # Strip the _comment key before sending to the API.
+          PAYLOAD=$(jq 'del(._comment)' "$FILE")
+          echo "Applying branch protection to refs/heads/${BRANCH}:"
+          echo "$PAYLOAD" | jq .
+          echo "$PAYLOAD" | gh api -X PUT \
+            "repos/${{ github.repository }}/branches/${BRANCH}/protection" \
+            --input -
+
+  drift:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      administration: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Diff live branch protection vs committed JSON
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          configs=(.github/branch-protection/*.json)
+          if [[ ${#configs[@]} -eq 0 ]]; then
+            echo "No branch-protection configs found — nothing to diff."
+            exit 0
+          fi
+          drift=0
+          for f in "${configs[@]}"; do
+            branch=$(basename "$f" .json)
+            echo "::group::Diffing refs/heads/${branch}"
+            expected=$(jq 'del(._comment)' "$f")
+            # Live API returns extra read-only fields; project to the keys we manage.
+            live=$(gh api "repos/${{ github.repository }}/branches/${branch}/protection" 2>/dev/null \
+              | jq '{
+                  required_status_checks: (.required_status_checks // null) | if . then {strict: .strict, contexts: .contexts} else null end,
+                  enforce_admins: (.enforce_admins.enabled // false),
+                  required_pull_request_reviews: (.required_pull_request_reviews // null) | if . then {dismiss_stale_reviews, require_code_owner_reviews, required_approving_review_count, require_last_push_approval} else null end,
+                  restrictions: null,
+                  required_linear_history: (.required_linear_history.enabled // false),
+                  allow_force_pushes: (.allow_force_pushes.enabled // false),
+                  allow_deletions: (.allow_deletions.enabled // false),
+                  block_creations: (.block_creations.enabled // false),
+                  required_conversation_resolution: (.required_conversation_resolution.enabled // false),
+                  lock_branch: (.lock_branch.enabled // false),
+                  allow_fork_syncing: (.allow_fork_syncing.enabled // false)
+                }')
+            expected_norm=$(echo "$expected" | jq -S .)
+            live_norm=$(echo "$live"     | jq -S .)
+            if [[ "$expected_norm" != "$live_norm" ]]; then
+              drift=1
+              echo "::warning::Branch protection drift on ${branch}"
+              diff <(echo "$expected_norm") <(echo "$live_norm") || true
+            else
+              echo "✓ ${branch} matches committed config"
+            fi
+            echo "::endgroup::"
+          done
+          if [[ $drift -eq 1 ]]; then
+            echo "::error::Drift detected — re-run the apply job (workflow_dispatch) to reconcile."
+            exit 1
+          fi


### PR DESCRIPTION
Codifies main-branch protection in `.github/branch-protection/main.json` plus an `apply`/`drift` workflow. Stops out-of-band UI drift; produces an audit trail in git.