### PR TITLE
ci: add gitleaks secret-scanning + Azure-RBAC allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,22 @@ jobs:
         uses: docker://rhysd/actionlint:1.7.7
         with:
           args: -color
+
+  # Scan for accidentally committed secrets on every PR + push to main.
+  # gitleaks ships a default ruleset (AWS keys, GitHub tokens, Azure conn
+  # strings, JWT-shaped values, etc.). The repo-root .gitleaks.toml
+  # allowlists known false positives (Azure built-in RBAC role GUIDs).
+  gitleaks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+          GITLEAKS_ENABLE_SUMMARY: true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,29 @@
+# gitleaks config — extends the default ruleset with repo-specific allowlists
+# for known false positives. Re-test locally with `gitleaks detect --no-banner`.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Allowlists for known non-secret values"
+
+# Azure built-in role definition GUIDs are public, well-documented identifiers
+# (e.g. https://learn.microsoft.com/azure/role-based-access-control/built-in-roles).
+# They look like API keys to the generic-api-key heuristic but are not secrets.
+paths = [
+  '''infra/bicep/.*\.bicep$''',
+  '''infra/bicep/.*\.bicepparam$''',
+]
+
+# Belt and braces for the specific role-definition GUIDs we reference.
+# Adding regexes here means we don't have to allow-list every bicep file
+# that happens to mention an RBAC role.
+regexes = [
+  # User Access Administrator
+  '''18d7d88d-d35e-4fb5-a5c3-7773c20a72d9''',
+  # Key Vault Secrets User
+  '''4633458b-17de-408a-b874-0445c86b69e6''',
+  # Key Vault Administrator
+  '''00482a5a-887f-4fb3-b363-3b7fe8e74483''',
+  # Contributor
+  '''b24988ac-6180-42a0-ab88-20f7382dd24c''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,19 +4,13 @@
 useDefault = true
 
 [allowlist]
-description = "Allowlists for known non-secret values"
+description = "Allowlist specific known non-secret values. Do NOT add path-based excludes for IaC files — that would silence the very files most likely to leak."
 
 # Azure built-in role definition GUIDs are public, well-documented identifiers
-# (e.g. https://learn.microsoft.com/azure/role-based-access-control/built-in-roles).
+# (https://learn.microsoft.com/azure/role-based-access-control/built-in-roles).
 # They look like API keys to the generic-api-key heuristic but are not secrets.
-paths = [
-  '''infra/bicep/.*\.bicep$''',
-  '''infra/bicep/.*\.bicepparam$''',
-]
-
-# Belt and braces for the specific role-definition GUIDs we reference.
-# Adding regexes here means we don't have to allow-list every bicep file
-# that happens to mention an RBAC role.
+# Allowlist them by exact value, not by path, so any other suspicious string
+# in our Bicep modules is still scanned.
 regexes = [
   # User Access Administrator
   '''18d7d88d-d35e-4fb5-a5c3-7773c20a72d9''',
@@ -27,3 +21,4 @@ regexes = [
   # Contributor
   '''b24988ac-6180-42a0-ab88-20f7382dd24c''',
 ]
+


### PR DESCRIPTION
Adds `gitleaks-action` on every PR + push. Repo `.gitleaks.toml` allowlists public Azure RBAC role-definition GUIDs (false positives flagged as `generic-api-key`). Locally clean: "no leaks found" across 111 commits.