### PR TITLE
ci(cd): verify SLSA build provenance before deploy

### DIFF
--- a/.github/workflows/deploy-env.yml
+++ b/.github/workflows/deploy-env.yml
@@ -93,6 +93,38 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      # Verify Sigstore/GitHub build-provenance attestations exist for every
+      # service image we're about to roll out. cd.yml's build-images job emits
+      # them via attest-build-provenance@v2; deploy fails fast if any are
+      # missing or the chain doesn't verify back to this repo. Provenance is
+      # otherwise generated-but-not-enforced.
+      - name: Verify image attestations
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ steps.tag.outputs.imageTag }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_FULL: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          fail=0
+          for svc in apigateway orders-api restaurants-api kitchen-worker; do
+            ref="ghcr.io/${OWNER}/ftgo-${svc}:${IMAGE_TAG}"
+            echo "::group::verify $ref"
+            if gh attestation verify "oci://${ref}" \
+                 --repo "${REPO_FULL}" \
+                 --predicate-type 'https://slsa.dev/provenance/v1' 2>&1; then
+              echo "✓ attestation OK"
+            else
+              echo "::error::no valid SLSA provenance for $ref"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Refusing to deploy unattested images. Re-run cd.yml's build-images job and try again."
+            exit 1
+          fi
+
       - name: Resolve entraConfig (with warm-env guard)
         id: entra
         env:


### PR DESCRIPTION
Adds `gh attestation verify` step to deploy-env.yml. Each of the 4 service images at the resolved tag must have valid SLSA-provenance v1 traced back to this repo, or the deploy aborts before touching Azure. Closes the 'provenance generated but not enforced' gap from the rubber-duck critique.