### PR TITLE
chore(bicep): mark App Insights connection string + ikey @secure()

### DIFF
--- a/infra/bicep/modules/aca-stack.bicep
+++ b/infra/bicep/modules/aca-stack.bicep
@@ -11,6 +11,7 @@ param location string
 param containerAppsEnvironmentId string
 
 @description('Application Insights connection string injected into every app.')
+@secure()
 param appInsightsConnectionString string
 
 @description('Container registry base (e.g. ghcr.io/mghabin). Final image: <registry>/ftgo-<shortName>:<imageTag>.')

--- a/infra/bicep/modules/app-insights.bicep
+++ b/infra/bicep/modules/app-insights.bicep
@@ -29,10 +29,12 @@ resource ai 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
-@description('Connection string injected into each container app as APPLICATIONINSIGHTS_CONNECTION_STRING.')
+@description('Connection string injected into each container app as APPLICATIONINSIGHTS_CONNECTION_STRING. Marked @secure() so it does not appear in deployment history (the AccessKey embedded in the connection string grants telemetry ingest).')
+@secure()
 output connectionString string = ai.properties.ConnectionString
 
-@description('Legacy instrumentation key (kept for compatibility; prefer the connection string).')
+@description('Legacy instrumentation key (kept for compatibility; prefer the connection string). Marked @secure() for the same reason.')
+@secure()
 output instrumentationKey string = ai.properties.InstrumentationKey
 
 @description('Resource ID of the AI component.')

--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -19,6 +19,7 @@ param containerAppsEnvironmentId string
 param image string
 
 @description('Application Insights connection string injected as APPLICATIONINSIGHTS_CONNECTION_STRING.')
+@secure()
 param appInsightsConnectionString string
 
 @description('Logical environment name (dev/ppe/prod). Capitalized into ASPNETCORE_ENVIRONMENT.')


### PR DESCRIPTION
Marks AI module outputs and consumer params as `@secure()` so the embedded AccessKey doesn't leak into deployment history. Bicep build clean across all touched files.