### PR TITLE
ci: render code coverage summary in step output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,22 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      - name: Coverage summary
+        if: always()
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: ./TestResults/**/coverage.cobertura.xml
+          format: markdown
+          output: both
+          badge: true
+          hide_complexity: true
+          thresholds: '50 75'
+
+      - name: Append coverage to step summary
+        if: always() && hashFiles('code-coverage-results.md') != ''
+        run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
+
+
       - name: Format check
         run: dotnet format EntraAuthPatterns.slnx --verify-no-changes --no-restore --severity warn
 


### PR DESCRIPTION
Adds CodeCoverageSummary step that renders cobertura XML to a markdown badge in `$GITHUB_STEP_SUMMARY`. No new artifacts; reuses existing collection.