### PR TITLE
docs(operations): BRANCH_PROTECTION_TOKEN setup + Trivy/attestation failure modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,22 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      - name: Coverage summary
+        if: always()
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: ./TestResults/**/coverage.cobertura.xml
+          format: markdown
+          output: both
+          badge: true
+          hide_complexity: true
+          thresholds: '50 75'
+
+      - name: Append coverage to step summary
+        if: always() && hashFiles('code-coverage-results.md') != ''
+        run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
+
+
       - name: Format check
         run: dotnet format EntraAuthPatterns.slnx --verify-no-changes --no-restore --severity warn
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -49,6 +49,18 @@ gh workflow run branch-protection.yml
 The drift job will fail if anyone has changed protection rules in the
 GitHub UI without updating `main.json`.
 
+### One-time setup: BRANCH_PROTECTION_TOKEN secret
+
+The default `GITHUB_TOKEN` cannot manage branch protection — the API
+requires repo-administration permission, which the automatic workflow
+token cannot grant. Provision a fine-grained PAT (or, preferably, a
+GitHub App installation token) with **Administration: Read and write**
+scope on this repo, then store it as the repo secret
+`BRANCH_PROTECTION_TOKEN`. The apply and drift jobs both need it.
+
+Until that secret is set, the nightly drift cron will fail with a
+clear error. Tracked in issue #67.
+
 ## Nightly cost-safety
 
 `cd-cleanup.yml` runs at 03:00 UTC and scales every container app in
@@ -120,3 +132,13 @@ az containerapp logs show \
 * **Branch protection drift alert** — open `.github/branch-protection/main.json`,
   reconcile against the failure diff in the workflow log, commit a fix,
   then re-run `branch-protection.yml` to apply.
+* **CD `build-images` fails with Trivy CRITICAL/HIGH** — open the SARIF
+  upload in the Security tab to see the CVE list. Fix order:
+  bump the base image (Dockerfile FROM tag) and let Dependabot's
+  docker ecosystem PR land, OR rebuild after upstream pushes a fix.
+  Unfixable CVEs are already filtered (`ignore-unfixed: true`); a
+  failure means there *is* a fix available somewhere in the dep tree.
+* **CD aborts with "Refusing to deploy unattested images"** — image was
+  pushed before the SLSA provenance pipeline was added, or the
+  attestation got pruned. Re-run `cd.yml`'s `build-images` job to
+  rebuild and re-attest.


### PR DESCRIPTION
Adds two missing sections to the runbook for failure modes that landed in this sprint but weren't yet documented:

1. **BRANCH_PROTECTION_TOKEN one-time setup** — the default GITHUB_TOKEN cannot manage branch-protection rules; the workflow needs a fine-grained PAT (Administration: R/W) stored as repo secret. Tracks issue #67.

2. **Trivy CRITICAL/HIGH failures + unattested-image rejection** — points future on-call at the Security tab SARIF for CVE detail, explains `ignore-unfixed: true` semantics, and walks through rebuilding to refresh SLSA provenance.

Pure docs change. No CI risk.