### PR TITLE
fix(cd-cleanup): derive RG region from vars.LOCATION (not hardcoded eastus)

### DIFF
--- a/.github/workflows/cd-cleanup.yml
+++ b/.github/workflows/cd-cleanup.yml
@@ -29,10 +29,12 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Reset min/max replicas in rg-ftgo-${{ matrix.env }}-eastus
+      - name: Reset min/max replicas in rg-ftgo-${{ matrix.env }}-${{ vars.LOCATION || 'eastus' }}
+        env:
+          LOCATION: ${{ vars.LOCATION || 'eastus' }}
         run: |
           set -euo pipefail
-          RG="rg-ftgo-${{ matrix.env }}-eastus"
+          RG="rg-ftgo-${{ matrix.env }}-${LOCATION}"
           if ! az group show --name "$RG" --only-show-errors --output none 2>/dev/null; then
             echo "Resource group $RG does not exist — skipping."
             exit 0


### PR DESCRIPTION
Resolves the cd-cleanup half of #68.

`cd-cleanup.yml` was reaching into `rg-ftgo-${env}-eastus` regardless of where the env actually lives. If anyone deploys a non-prod env to a different region (e.g. for quota / availability reasons), the nightly scale-down silently no-ops on the wrong RG name and the cost-safety net stops working.

Now the workflow reads the per-environment GitHub var `LOCATION` (the same one that the dev/ppe/prod environments already use to thread region through to bicep) and falls back to `eastus` for backward compatibility — no required action for existing envs.

`actionlint` clean locally. Conflict-free with PR #48 (which only touched the `environment:` line).