### PR TITLE
fix(bootstrap): plumb LOCATION through bootstrap.{env}.bicepparam

### DIFF
--- a/infra/bicep/bootstrap.dev.bicepparam
+++ b/infra/bicep/bootstrap.dev.bicepparam
@@ -4,6 +4,6 @@
 using 'bootstrap.bicep'
 
 param environmentName = 'dev'
-param location        = 'eastus'
+param location        = readEnvironmentVariable('LOCATION', 'eastus')
 param githubOwner     = readEnvironmentVariable('GH_OWNER', 'mghabin')
 param githubRepo      = readEnvironmentVariable('GH_REPO',  'entra-auth-patterns-dotnet')

--- a/infra/bicep/bootstrap.ppe.bicepparam
+++ b/infra/bicep/bootstrap.ppe.bicepparam
@@ -4,6 +4,6 @@
 using 'bootstrap.bicep'
 
 param environmentName = 'ppe'
-param location        = 'eastus'
+param location        = readEnvironmentVariable('LOCATION', 'eastus')
 param githubOwner     = readEnvironmentVariable('GH_OWNER', 'mghabin')
 param githubRepo      = readEnvironmentVariable('GH_REPO',  'entra-auth-patterns-dotnet')

--- a/infra/bicep/bootstrap.prod.bicepparam
+++ b/infra/bicep/bootstrap.prod.bicepparam
@@ -4,6 +4,6 @@
 using 'bootstrap.bicep'
 
 param environmentName = 'prod'
-param location        = 'eastus'
+param location        = readEnvironmentVariable('LOCATION', 'eastus')
 param githubOwner     = readEnvironmentVariable('GH_OWNER', 'mghabin')
 param githubRepo      = readEnvironmentVariable('GH_REPO',  'entra-auth-patterns-dotnet')

--- a/scripts/bootstrap-env.sh
+++ b/scripts/bootstrap-env.sh
@@ -52,7 +52,7 @@ done
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GH_OWNER="${GH_OWNER:-$(gh repo view --json owner --jq .owner.login)}"
 GH_REPO="${GH_REPO:-$(gh repo view --json name --jq .name)}"
-LOCATION="${LOCATION:-eastus}"
+export LOCATION="${LOCATION:-eastus}"
 ACCOUNT_JSON="$(az account show -o json)"
 TENANT_ID=$(jq -r .tenantId <<<"$ACCOUNT_JSON")
 SUB_ID=$(jq    -r .id       <<<"$ACCOUNT_JSON")


### PR DESCRIPTION
Resolves bootstrap half of #68. Mirrors the existing `azure.{env}.bicepparam` pattern (`readEnvironmentVariable('LOCATION', 'eastus')`). Script now `export`s LOCATION so the bicep CLI inherits it.

Verified: `LOCATION=westeurope bicep build-params …` resolves to `location = westeurope`.