### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,55 @@
+name: scorecard
+# OpenSSF Scorecard supply-chain hygiene check.
+# Runs weekly + on every push to main; uploads results to:
+#   - GitHub Security tab (SARIF)
+#   - api.securityscorecards.dev (so the badge in README resolves)
+# Docs: https://github.com/ossf/scorecard-action
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '17 4 * * 2'   # 04:17 UTC every Tuesday
+  push:
+    branches: [main]
+
+permissions: read-all
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for SARIF upload to code-scanning.
+      security-events: write
+      # Required for the OIDC publish to securityscorecards.dev.
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results back to securityscorecards.dev (powers the public badge).
+          publish_results: true
+
+      # Keep raw results around for 5 days so a failed run can be inspected
+      # without re-running the analysis (which costs API calls).
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@8c78abb9b62512e3c45dea6559ffd924ed8549c8 # v3.28.0
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Adds the canonical supply-chain-hygiene check for public OSS samples.

Runs:
* On push to `main`
* On every `branch_protection_rule` change (so policy regressions are caught)
* Weekly cron

Publishes:
* SARIF to the GitHub Security tab (alongside Trivy + gitleaks)
* Results to `securityscorecards.dev` so the public Scorecard badge resolves

Actions pinned by full SHA — satisfies Scorecard's own Pinned-Dependencies check.

Permissions tight: `read-all` workflow default, per-job `security-events: write` + `id-token: write` only where required.