### PR TITLE
ci: pin all third-party GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Apply branch protection from JSON
         env:
@@ -56,7 +56,7 @@ jobs:
   drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Diff live branch protection vs committed JSON
         env:

--- a/.github/workflows/cd-cleanup.yml
+++ b/.github/workflows/cd-cleanup.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         env: [dev, ppe]
     steps:
-      - uses: azure/login@v3
+      - uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,7 +62,7 @@ jobs:
     outputs:
       imageTag: ${{ steps.meta.outputs.imageTag }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Compute image metadata
         id: meta
@@ -82,9 +82,9 @@ jobs:
             echo "imageTag=sha-${SHORT_SHA}"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Build & push ${{ matrix.project }}
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: Dockerfile
@@ -117,7 +117,7 @@ jobs:
       # attestation store + Sigstore transparency log. Verifies who built the
       # image, on which commit, with which workflow.
       - name: Generate build provenance attestation
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/ftgo-${{ steps.meta.outputs.SHORT_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -140,7 +140,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
         with:
           sarif_file: trivy-${{ steps.meta.outputs.SHORT_NAME }}.sarif
           category: trivy-${{ steps.meta.outputs.SHORT_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,15 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup .NET (from global.json)
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           global-json-file: global.json
 
       - name: Cache NuGet
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/packages.lock.json') }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage
           path: ./TestResults/**/coverage.cobertura.xml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Coverage summary
         if: always()
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: ./TestResults/**/coverage.cobertura.xml
           format: markdown
@@ -79,8 +79,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
@@ -88,7 +88,7 @@ jobs:
   bicep-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Bicep CLI
         run: az bicep install
@@ -150,7 +150,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run actionlint
         uses: docker://rhysd/actionlint:1.7.7
@@ -166,11 +166,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false

--- a/.github/workflows/deploy-env.yml
+++ b/.github/workflows/deploy-env.yml
@@ -73,7 +73,7 @@ jobs:
       scalar_url: ${{ steps.deploy.outputs.scalar_url }}
       apigateway_redirect: ${{ steps.deploy.outputs.apigateway_redirect }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Resolve image tag
         id: tag
@@ -87,7 +87,7 @@ jobs:
           fi
           echo "imageTag=${TAG}" >> "$GITHUB_OUTPUT"
 
-      - uses: azure/login@v3
+      - uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/wi-demo.yml
+++ b/.github/workflows/wi-demo.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: demo
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Azure login (federated)
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
Migrates from mutable major-version tags (e.g. `actions/checkout@v6`)
to immutable commit SHAs with version comments (e.g.
`actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6`).

Why
- Tag-replacement attacks: a compromised maintainer (or a stolen PAT)
  can re-point a major tag to a malicious commit and silently affect
  every downstream workflow on the next run. SHA pinning eliminates
  that vector.
- Satisfies OpenSSF Scorecard `Pinned-Dependencies` (the workflow we
  added in #78). Brings our own score in line with what we publish.
- Aligns with the dotnet-engineering-guide CI/CD section: third-party
  actions "must be SHA-pinned with a version comment".

Coverage
- 13 distinct actions across 6 workflow files (cd.yml, ci.yml,
  deploy-env.yml, branch-protection.yml, cd-cleanup.yml, wi-demo.yml).
- scorecard.yml was already SHA-pinned at creation.
- Trivy was already SHA-pinned (post-supply-chain-compromise).
- Reusable workflow refs (`./.github/workflows/deploy-env.yml`) are
  not third-party — left as-is.

Maintenance
- Dependabot's github-actions ecosystem honors the `# vN` comment
  and will open weekly grouped bumps that update both the SHA and
  the comment together. Existing `groups: actions` config carries
  over unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
