### PR TITLE
fix(infra): worker container apps default to minReplicas=0

### DIFF
--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -120,7 +120,15 @@ resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
         }
       ]
       scale: {
-        minReplicas: enableIngress ? 0 : 1
+        // Workers (no ingress) historically defaulted to min=1 because there's no HTTP
+        // scaler to wake them on demand. That keeps a vCPU pinned 24/7 (~$2.4/mo per
+        // worker on dev tier) for a probe-once-and-exit pattern. Switching to min=0:
+        // the worker runs once on revision creation/update (executes the probe, exits),
+        // then stays at 0 replicas until the next deploy. CPU-utilization scaler stays
+        // wired so it can scale 0→N if the process ever does sustained work.
+        // Honest cost note: README "$0/mo at idle" is now true for workers too; for a
+        // fully run-on-demand worker, prefer Microsoft.App/jobs over containerApps.
+        minReplicas: 0
         maxReplicas: 3
         rules: enableIngress ? [
           {


### PR DESCRIPTION
Workers (containers without HTTP ingress — currently just kitchen-worker)
previously defaulted to `minReplicas: 1` because there's no HTTP scaler
to wake them on demand. For a probe-once-and-exit pattern that keeps one
vCPU pinned 24/7 (~$2.4/mo per worker on dev tier).

Caught when month-to-date dev cost was $13/mo instead of the README's
promised "$0/mo at idle" — $2.4 of that was kitchen-worker, the
remaining $10 was 6 stale orphan apps (accountingservice, …) deleted
manually out-of-band.

Switching to minReplicas=0:
- Worker runs once on revision creation/update (executes probe, exits).
- After exit Container Apps does not restart it (no scaler trigger,
  desired=0).
- CPU-utilization custom scaler kept in place so a worker that does
  sustained work can still scale 0→N.

Honest follow-up: a worker that's truly "run on every push, then
nothing" should be a `Microsoft.App/jobs` resource, not a Container
App. Filed for later.

Verified the live resource was patched out-of-band:
  az containerapp update -g rg-ftgo-dev-eastus -n ftgo-dev-kitchen-worker-eus \
    --min-replicas 0 --max-replicas 3
This commit just makes the next bicep deploy stop reverting that.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
