### PR TITLE
fix(infra): cap dev container apps to bound worst-case cost (~$30/mo max)

### DIFF
--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -28,11 +28,16 @@ param environmentName string
 @description('Tags applied to the container app.')
 param tags object = {}
 
-@description('CPU cores per replica.')
-param cpu string = '0.5'
+@description('CPU cores per replica. Default 0.25 keeps dev cost-bounded; bump to 0.5+ for ppe/prod via parameter override.')
+param cpu string = '0.25'
 
-@description('Memory per replica.')
-param memory string = '1.0Gi'
+@description('Memory per replica. Default 0.5Gi keeps dev cost-bounded; bump to 1.0Gi+ for ppe/prod via parameter override.')
+param memory string = '0.5Gi'
+
+@description('Maximum replicas the HTTP/CPU scaler is allowed to spin up. Default 1 caps dev at a known-tiny worst case (4 apps × 1 replica × 0.25 vCPU ≈ \$16/mo if pinned 24/7); ppe/prod should override.')
+@minValue(1)
+@maxValue(30)
+param maxReplicas int = 1
 
 @description('When false, the app has no public ingress, no HTTP probe, and uses CPU-based scaling. Used for headless worker services.')
 param enableIngress bool = true
@@ -129,7 +134,7 @@ resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
         // Honest cost note: README "$0/mo at idle" is now true for workers too; for a
         // fully run-on-demand worker, prefer Microsoft.App/jobs over containerApps.
         minReplicas: 0
-        maxReplicas: 3
+        maxReplicas: maxReplicas
         rules: enableIngress ? [
           {
             name: 'http-concurrency'


### PR DESCRIPTION
## Why

Cost incident triage (see the $13 MTD spike investigated in the previous PRs) revealed that the dev environment's per-replica defaults — `cpu=0.5`, `memory=1.0Gi`, `maxReplicas=3` — gave us a worst-case bill of **~$500/mo** if anything ever pinned all 4 apps at max under sustained load. For a sample repo that promises *"$0/mo at idle"*, that's an unacceptable blast radius.

Reactive controls (cron-based GitHub Action / Azure budget webhook) all suffer from Azure's 8–24h cost-data latency — by the time they fire, you've already burned days of cost. The honest fix is **preventive**: cap the architecture so the math makes a big bill physically impossible.

## What

In `infra/bicep/modules/container-app.bicep`:
| Knob | Before | After |
|---|---|---|
| `cpu` default | `'0.5'` | `'0.25'` |
| `memory` default | `'1.0Gi'` | `'0.5Gi'` |
| `maxReplicas` | hardcoded `3` | new param, default `1`, range `1..30` |

ppe/prod can override per-env when those environments are bootstrapped; the parameter shape preserves the option without forcing a Bicep edit.

## Cost math (worst case, 24/7, all 4 apps pinned at max=1)

- vCPU:   4 × 0.25 × 730h × $0.000024/s × 3600 ≈ **$15.8/mo**
- memory: 4 × 0.5 × 730h × $0.0000025/s × 3600 ≈ **$13.1/mo**
- **Total: <$30/mo physical ceiling**, regardless of traffic, DDoS, or runaway loops

Combined with the **$2 subscription budget alert** I wired live (50% / 80% / 100% / forecast notifications to mghabin@…), this gives both:
- an **absolute cap** (math), and
- an **early warning** (email at $1)

## Live state

Already applied to all 4 running apps via `az containerapp update --cpu 0.25 --memory 0.5Gi --min-replicas 0 --max-replicas 1` so today's bill stops climbing immediately. This PR makes the floor permanent in IaC; without it, the next CD run would regress to the higher numbers from the existing template defaults.

## Verification

- `az bicep build` clean on `container-app.bicep` and `azure.bicep`
- Live apps confirmed via `az containerapp list` (all 4: 0.25 / 0.5Gi / 0–1)