### PR TITLE
chore(infra): move BFF federated credential into Bicep (Microsoft.Graph extension)

### DIFF
--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -29,7 +29,11 @@ param scalarRedirectUri string = 'https://localhost:7101/scalar/v1'
 @description('Map of worker MI key → principalId (system MI of the corresponding ACA app). Passed in by provision-apps.sh after reading azure.bicep outputs. Empty during a cold deploy — the script re-runs the tenant deploy with this populated once the ACA stack exists.')
 param workerMiPrincipalIds object = {}
 
+@description('clientId (appId) of the BFF Container App\'s system-assigned MI. Used as the subject of the BFF federated identity credential. Empty on cold deploy; populated on the warm wire-back run by provision-apps.sh.')
+param bffMiClientId string = ''
+
 var effectivePrefix = '${prefix}-${environmentName}'
+var bffFicName      = 'aca-${environmentName}-apigateway'
 
 module appRegistrations 'modules/app-registrations.bicep' = {
   name: 'app-registrations'
@@ -38,6 +42,8 @@ module appRegistrations 'modules/app-registrations.bicep' = {
     prefix:                effectivePrefix
     apiGatewayRedirectUri: apiGatewayRedirectUri
     scalarRedirectUri:     scalarRedirectUri
+    bffMiClientId:         bffMiClientId
+    bffFicName:            bffFicName
   }
 }
 

--- a/infra/bicep/modules/app-registrations.bicep
+++ b/infra/bicep/modules/app-registrations.bicep
@@ -22,6 +22,12 @@ param apiGatewayRedirectUri string
 @description('SPA redirect URI registered on the BFF for Scalar PKCE callback.')
 param scalarRedirectUri string
 
+@description('clientId (appId) of the BFF Container App\'s system-assigned MI. Used as the subject of the BFF federated identity credential. Empty string on cold deploy (the BFF MI does not yet exist) — the FIC is then skipped and provision-apps.sh re-runs the tenant deployment with this populated.')
+param bffMiClientId string = ''
+
+@description('Name of the BFF federated identity credential. Conventionally aca-{env}-apigateway. Ignored when bffMiClientId is empty.')
+param bffFicName string = ''
+
 var ordersReadScopeId        = guid(tenantId, '${prefix}-orders-api',      'orders.read')
 var ordersProcessRoleId      = guid(tenantId, '${prefix}-orders-api',      'Orders.Process')
 var restaurantsReadRoleId    = guid(tenantId, '${prefix}-restaurants-api', 'Restaurants.Read.All')
@@ -60,6 +66,24 @@ resource apiGateway 'Microsoft.Graph/applications@v1.0' = {
 
 resource apiGatewaySp 'Microsoft.Graph/servicePrincipals@v1.0' = {
   appId: apiGateway.appId
+}
+
+// Federated identity credential on the BFF app reg trusting the BFF Container App's
+// system-assigned MI. The BFF mints a token with audience `api://AzureADTokenExchange`
+// using its system MI; the FIC tells Entra to accept that token as proof that the
+// caller IS the BFF app reg, enabling SignedAssertionFromManagedIdentity for OBO/S2S
+// without certs or secrets on the box.
+//
+// Skipped on cold deploy (bffMiClientId == '' because the Container App + its MI do
+// not yet exist). provision-apps.sh re-runs this template once azure.bicep has been
+// deployed and the MI clientId is known.
+resource apiGatewayFic 'Microsoft.Graph/applications/federatedIdentityCredentials@v1.0' = if (!empty(bffMiClientId)) {
+  name:        '${apiGateway.uniqueName}/${bffFicName}'
+  audiences:   [ 'api://AzureADTokenExchange' ]
+  description: 'ACA system MI → BFF app reg (SignedAssertionFromManagedIdentity)'
+  #disable-next-line no-hardcoded-env-urls
+  issuer:      'https://login.microsoftonline.com/${tenantId}/v2.0'
+  subject:     bffMiClientId
 }
 
 resource ordersApi 'Microsoft.Graph/applications@v1.0' = {

--- a/scripts/provision-apps.sh
+++ b/scripts/provision-apps.sh
@@ -11,18 +11,18 @@
 #   1. (cold only) Deploy infra/bicep/azure.bicep with entraConfig={} to create the
 #      Container Apps + system MIs. Skipped when the kitchen-worker container app
 #      already exists.
-#   2. Read each container app's system-assigned MI principalId.
+#   2. Read each container app's system-assigned MI principalId AND resolve the BFF
+#      MI's clientId (subject of the BFF federated credential).
 #   3. Deploy infra/bicep/main.bicep at tenant scope to (re-)create the per-env Entra
-#      app registrations and grant Orders.Process to the kitchen-worker MI's principalId
-#      (Microsoft.Graph extension is idempotent — matches by uniqueName).
+#      app registrations, grant Orders.Process to the kitchen-worker MI's principalId,
+#      AND create the BFF federated identity credential (subject = BFF MI clientId,
+#      audience = api://AzureADTokenExchange) — all declaratively via the Microsoft.Graph
+#      Bicep extension. Idempotent (matches by uniqueName).
 #   4. Resolve the kitchen-worker MI's appId (clientId), used in OrdersApi's
 #      EntraAuth__AllowedClientApps allow-list.
-#   5. Create the federated identity credential on the BFF app reg trusting the BFF's
-#      ACA system MI as a SignedAssertionFromManagedIdentity issuer (BFF's confidential-
-#      client S2S/OBO calls require an app-reg identity).
-#   6. Re-deploy infra/bicep/azure.bicep with a populated entraConfig object. ARM merges
+#   5. Re-deploy infra/bicep/azure.bicep with a populated entraConfig object. ARM merges
 #      the env-var changes into the container app templates declaratively.
-#   7. Publish entraConfig as the ENTRA_CONFIG_JSON env-level GitHub variable so cd.yml
+#   6. Publish entraConfig as the ENTRA_CONFIG_JSON env-level GitHub variable so cd.yml
 #      can re-pass it on subsequent CD redeploys.
 #
 # IMAGE_TAG: optional; defaults to `latest`.
@@ -155,7 +155,11 @@ echo "    orders-api          fqdn=$ORDERS_FQDN"
 echo "    restaurants-api     fqdn=$RESTAURANTS_FQDN"
 echo "    kitchen-worker MI=${KITCHEN_MI:0:8}…"
 
-# 3. Tenant-scope deployment for the per-env app regs + MI role grants.
+# 3. Tenant-scope deployment for the per-env app regs + MI role grants + BFF FIC.
+#    On a cold deploy bffMiClientId='' so the FIC resource short-circuits in Bicep.
+#    On the warm wire-back run (after step 1 created the BFF Container App) we pass
+#    its MI clientId so the FIC is created declaratively in the same deploy as the
+#    app reg. No more split-brain between Bicep + `az ad app federated-credential`.
 echo "==> Deploying main.bicep (env=$ENV)"
 ENTRA_DEPLOY="ftgo-entra-${ENV}-$(date -u +%Y%m%d%H%M%S)"
 AGW_REDIRECT="https://${APIGATEWAY_FQDN}/signin-oidc"
@@ -165,6 +169,12 @@ SCALAR_REDIRECT="https://${APIGATEWAY_FQDN}/scalar/v1"
 export AZURE_TENANT_ID="$TENANT_ID"
 
 WORKER_MI_JSON=$(jq -nc --arg k "$KITCHEN_MI" '{kitchenWorker: $k}')
+
+# Resolve the BFF MI clientId (appId of the apigateway's system-assigned MI service
+# principal). This is the FIC's `subject` claim. APIGATEWAY_MI is the MI's principalId
+# (objectId of the SP) — we need its appId.
+BFF_MI_CLIENT_ID=$(az ad sp show --id "$APIGATEWAY_MI" --query appId -o tsv --only-show-errors)
+echo "    bff MI clientId = $BFF_MI_CLIENT_ID"
 
 if [[ "${WHAT_IF:-0}" == "1" ]]; then
   echo "    WHAT_IF=1 — preview only, skipping tenant-scope create"
@@ -179,6 +189,7 @@ if [[ "${WHAT_IF:-0}" == "1" ]]; then
         apiGatewayRedirectUri="$AGW_REDIRECT" \
         scalarRedirectUri="$SCALAR_REDIRECT" \
         workerMiPrincipalIds="$WORKER_MI_JSON" \
+        bffMiClientId="$BFF_MI_CLIENT_ID" \
     --only-show-errors
   exit 0
 fi
@@ -192,6 +203,7 @@ az deployment tenant create \
       apiGatewayRedirectUri="$AGW_REDIRECT" \
       scalarRedirectUri="$SCALAR_REDIRECT" \
       workerMiPrincipalIds="$WORKER_MI_JSON" \
+      bffMiClientId="$BFF_MI_CLIENT_ID" \
   --only-show-errors --output none
 
 APPS=$(az deployment tenant show --name "$ENTRA_DEPLOY" --query 'properties.outputs.apps.value' -o json --only-show-errors)
@@ -208,37 +220,7 @@ echo "==> Resolving kitchen-worker MI clientId"
 KITCHEN_MI_CLIENT_ID=$(az ad sp show --id "$KITCHEN_MI" --query appId -o tsv --only-show-errors)
 echo "    kitchen-worker clientId = $KITCHEN_MI_CLIENT_ID"
 
-# 5. Federated identity credential on the BFF app reg ← BFF ACA system MI.
-#
-#    SignedAssertionFromManagedIdentity flow: the BFF uses its system-assigned MI to mint
-#    a token with audience `api://AzureADTokenExchange`. The BFF app reg trusts that
-#    token via a federated credential whose issuer is the tenant STS, subject is the MI's
-#    clientId. Then the BFF can do confidential-client S2S/OBO calls under its app-reg
-#    identity without any cert or secret on the box.
-#
-#    Workers (Kitchen) do NOT need this — they call APIs as the MI directly.
-echo "==> Federated identity credential (BFF app reg ← BFF MI)"
-ISSUER="https://login.microsoftonline.com/${TENANT_ID}/v2.0"
-BFF_APP_OBJ_ID=$(az ad app show --id "$BFF_APPID" --query id -o tsv --only-show-errors)
-BFF_MI_CLIENT_ID=$(az ad sp show --id "$APIGATEWAY_MI" --query appId -o tsv --only-show-errors)
-BFF_FIC_NAME="aca-${ENV}-apigateway"
-
-if az ad app federated-credential list --id "$BFF_APP_OBJ_ID" \
-      --query "[?name=='${BFF_FIC_NAME}']" -o tsv --only-show-errors 2>/dev/null | grep -q .; then
-  echo "    FIC '${BFF_FIC_NAME}' already exists"
-else
-  az ad app federated-credential create --id "$BFF_APP_OBJ_ID" --parameters "$(jq -nc \
-    --arg name "$BFF_FIC_NAME" --arg issuer "$ISSUER" --arg sub "$BFF_MI_CLIENT_ID" '{
-      name: $name,
-      issuer: $issuer,
-      subject: $sub,
-      description: "ACA system MI → BFF app reg (SignedAssertionFromManagedIdentity)",
-      audiences: ["api://AzureADTokenExchange"]
-    }')" --only-show-errors --output none
-  echo "    created FIC '${BFF_FIC_NAME}' (subject=${BFF_MI_CLIENT_ID})"
-fi
-
-# 6. Build full entraConfig and re-deploy azure.bicep. This is the step that wires env
+# 5. Build full entraConfig and re-deploy azure.bicep. This is the step that wires env
 #    vars into the container app templates declaratively; subsequent CD redeploys with
 #    the same entraConfig will be no-ops on env vars.
 echo "==> Wiring entraConfig into azure.bicep"


### PR DESCRIPTION
## Why

`scripts/provision-apps.sh` had the last remaining `az ad app federated-credential` call — bespoke bash that ran *outside* the IaC, even though every other app-registration concern is already declared via the Microsoft.Graph Bicep extension. This was a leftover from before the extension supported FICs. Two tools managing the same Entra surface = drift risk + two error surfaces to debug.

## What

Add the FIC as a sibling resource to its parent `apiGateway` application in `app-registrations.bicep`:

```bicep
  name:        '${apiGateway.uniqueName}/${bffFicName}'
  audiences:   [ 'api://AzureADTokenExchange' ]
  description: 'ACA system MI → BFF app reg (SignedAssertionFromManagedIdentity)'
  issuer:      'https://login.microsoftonline.com/${tenantId}/v2.0'
  subject:     bffMiClientId
}
```


## Impact

| Metric | Before | After |
|---|---|---|
| LOC in `provision-apps.sh` | 312 | 290 |
| External CLI calls for FICs | `az ad app show` + `az ad app federated-credential list` + `az ad app federated-credential create` | none (Bicep does it) |
| Workflow steps in script header | 7 | 6 |
| Tools managing Entra surface | 2 (Bicep + az CLI) | 1 (Bicep) |

## Verification

- `az bicep build infra/bicep/main.bicep` — clean
- `bash -n scripts/provision-apps.sh` — clean
- Idempotency preserved: Microsoft.Graph extension matches by uniqueName, so re-running the same template against an env that already has the FIC is a no-op (same as the previous `if list ... else create` bash dance, but enforced by ARM)