### PR TITLE
fix(ci): pinact validate-only mode (skip_push) + canonicalize version comment

### DIFF
--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -27,12 +27,17 @@ jobs:
     name: Verify Action pins
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:
+          # Validate-only: do not auto-push fix commits.
+          # PRs from same-repo branches don't get contents:write on GITHUB_TOKEN,
+          # and on main, failing CI loudly is preferable to a silent "pinact" bot
+          # commit (author should run `pinact run --fix` locally instead).
+          skip_push: "true"
           # --check: fail if any action is unpinned (mutable ref).
-          # --verify: fail if a pinned SHA does not match the version comment
-          #   (catches the annotated-tag-object-SHA bug).
+          # --verify: fail if pinned SHA does not match the version comment
+          #   (catches the annotated-tag-object-SHA bug fixed in PR #87).
           pinact_opts: --check --verify
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

The pinact workflow added in PR #87 was failing on PR #89 with:
```
Resource not accessible by integration - https://docs.github.com/rest/git/trees#create-a-tree
```

Two root causes:

1. **Default pinact-action mode is 'fix and push'**, which requires `contents: write` on `GITHUB_TOKEN`. Same-repo PR branches don't get write permissions on the default token, so trying to push a fix commit fails.
2. **Version-comment mismatch**: I had `actions/checkout@... # v6` (major only) but pinact normalizes to the canonical tag `# v6.0.2`. The implicit fix diff caused `--check` to fail.

## Fix

- `skip_push: "true"` — validate-only. Authors who hit unpinned actions run `pinact run --fix` locally and commit explicitly. That's cleaner than a silent pinact-bot commit on every PR.
- Canonicalize `# v6` → `# v6.0.2`.

## Verified

```
$ pinact run --check --verify .github/workflows/*.yml; echo $?
0
```

Once this merges, PR #89 should rebase and pass.