### PR TITLE
chore(infra): explicit dependsOn + FIC/role-assignment idempotency docs + lint-suppression rationale

### DIFF
--- a/infra/bicep/azure.bicep
+++ b/infra/bicep/azure.bicep
@@ -118,6 +118,20 @@ module acaStack 'modules/aca-stack.bicep' = {
     entraConfig:                 entraConfig
     tags:                        tags
   }
+  // Implicit dependencies via `appInsights.outputs.connectionString` (and the
+  // downstream `kvRbac` consumption of `keyVault`) are technically sufficient,
+  // but mghabin/infra-engineering-guide ch02 §3 ("explicit, reviewable
+  // composition") favours making cross-module ordering visible at the call
+  // site — it survives refactors that drop an output reference and keeps the
+  // dependency graph greppable. keyVault is listed here even though no output
+  // is consumed by acaStack so the apps never start before the secret store
+  // they will eventually be granted RBAC on exists. appInsights is listed
+  // alongside it to keep the pair symmetric and self-documenting; the
+  // no-unnecessary-dependson lint correctly flags it as redundant given the
+  // existing connectionString reference, but the explicit listing is the
+  // intended documentation.
+  #disable-next-line no-unnecessary-dependson
+  dependsOn: [ keyVault, appInsights ]
 }
 
 module kvRbac 'modules/key-vault-rbac.bicep' = {

--- a/infra/bicep/modules/aca-stack.bicep
+++ b/infra/bicep/modules/aca-stack.bicep
@@ -29,7 +29,23 @@ param tags object = {}
 @description('Resolved Entra wiring (tenantId, app reg appIds, kitchen-worker MI clientId, downstream FQDNs). Empty `{}` on cold deploy → no Entra env vars are injected and apps fall back to appsettings.json placeholders. Populated by scripts/provision-apps.sh after Entra app regs and worker MI are known.')
 param entraConfig object = {}
 
-@description('Service definitions. project = csproj folder name; shortName = lowercase image/name suffix; key = stable Bicep map key (camelCase) used to dispatch env vars and build the output map; isWebApp = whether to expose HTTP ingress + /health/live + /health/ready probes.')
+// REQUIRED ORDER: services[0]=apiGateway, services[1]=ordersApi,
+//                 services[2]=restaurantsApi, services[3]=kitchenWorker.
+// The `services` output below indexes containerApps[] positionally because
+// Bicep does not allow for-expressions inside `toObject(...)` for output
+// values (BCP138) AND vars cannot reference module outputs (BCP182). Until
+// that limitation is lifted (tracked as a follow-up to migrate to a true
+// keyed-map output), callers MUST preserve both the length AND the order
+// of the default array — overriding with a different ordering will silently
+// produce a mis-keyed `services` map (e.g. apiGateway.fqdn pointing at the
+// orders-api ingress). Bicep has no `assert` keyword, so this constraint
+// is enforced by convention + review, not at template-evaluation time.
+@description('Service definitions. project = csproj folder name; shortName = lowercase image/name suffix; key = stable Bicep map key (camelCase) used to dispatch env vars and build the output map; isWebApp = whether to expose HTTP ingress + /health/live + /health/ready probes. REQUIRED ORDER: [0]=apiGateway, [1]=ordersApi, [2]=restaurantsApi, [3]=kitchenWorker — the `services` output is positionally keyed against this ordering. Do NOT reorder or resize without also rewriting the `services` output map below.')
+@metadata({
+  requiredOrder:    [ 'apiGateway', 'ordersApi', 'restaurantsApi', 'kitchenWorker' ]
+  requiredLength:   4
+  orderingConstraint: 'The `services` output below is positionally keyed against this array (containerApps[0]=apiGateway, etc). Reordering or resizing produces a silently mis-keyed output — do not override unless you also rewrite the output map.'
+})
 param services array = [
   { project: 'Ftgo.ApiGateway',      shortName: 'apigateway',       key: 'apiGateway',     isWebApp: true  }
   { project: 'Ftgo.Orders.Api',      shortName: 'orders-api',       key: 'ordersApi',      isWebApp: true  }

--- a/infra/bicep/modules/app-registrations.bicep
+++ b/infra/bicep/modules/app-registrations.bicep
@@ -1,6 +1,19 @@
 metadata name = 'app-registrations'
 metadata description = 'Provisions the 3 FTGO Entra app registrations + service principals (BFF, Orders API, Restaurants API) and exposes deterministic scope/role IDs. Workers run as Managed Identity and do not need their own app reg.'
 
+// IMPORTANT: bffMiClientId must NEVER be passed as empty on a re-run after the
+// initial warm deploy. The FIC resource depends on this value as its 'subject'.
+// If you re-run with an empty bffMiClientId, the FIC will be deleted, causing
+// the BFF to lose its trust relationship with the BFF UAMI. The bootstrap
+// flow (scripts/provision-apps.sh) must always pass the populated value.
+//
+// Cold-deploy semantics (bffMiClientId == '') are intentional and safe ONLY
+// before the BFF Container App + its system-assigned MI exist. Once the FIC
+// has been created, every subsequent tenant-scope deploy MUST resolve and
+// pass the BFF MI clientId or the Microsoft.Graph extension will reconcile
+// the FIC out of existence and break SignedAssertionFromManagedIdentity for
+// the BFF until the next provision-apps.sh run.
+
 // Scope/role IDs are deterministic GUIDs of (tenantId, app, value) so callers' references survive re-deploys.
 
 extension graphV1
@@ -81,6 +94,9 @@ resource apiGatewayFic 'Microsoft.Graph/applications/federatedIdentityCredential
   name:        '${apiGateway.uniqueName}/${bffFicName}'
   audiences:   [ 'api://AzureADTokenExchange' ]
   description: 'ACA system MI → BFF app reg (SignedAssertionFromManagedIdentity)'
+  // Microsoft Entra v2.0 token endpoint issuer. This is THE canonical issuer
+  // for FIC trust on Microsoft Entra ID; suppressing no-hardcoded-env-urls is
+  // intentional. Reference: https://learn.microsoft.com/entra/workload-id/workload-identity-federation
   #disable-next-line no-hardcoded-env-urls
   issuer:      'https://login.microsoftonline.com/${tenantId}/v2.0'
   subject:     bffMiClientId

--- a/infra/bicep/modules/cd-bootstrap.bicep
+++ b/infra/bicep/modules/cd-bootstrap.bicep
@@ -38,9 +38,23 @@ resource fic 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentity
 }
 
 // Deterministic GUID → idempotent re-runs (same scope+principal+role → same name).
-// Note: if the UAMI is ever DELETED and recreated with the same name, mi.id stays
-// stable but its principalId changes; you must also delete the old role assignments
-// before re-running, or Azure will reject the update as immutable.
+//
+// NOTE: Role assignments are scoped to the UAMI's principalId at creation.
+// If you delete and recreate the CD UAMI with the same name, the principalId
+// changes; the OLD role assignments will linger and the deployment will fail
+// with 'role assignment already exists'. Manually delete the old assignments
+// before re-running. See operations.md §<add-section> for the recovery
+// procedure.
+//
+// Concretely: `mi.id` (resourceId) stays stable across delete+recreate
+// because it is derived from name+RG, so `guid(rg.id, mi.id, roleId)` —
+// which we use as the assignment name — also stays stable. ARM keys role
+// assignments by name (immutable principalId on the existing record), so
+// the redeploy attempts to update an immutable field and 409s.
+//
+// Recovery: `az role assignment delete --assignee <old-principalId>` (or
+// `az role assignment list --scope <rg> --query "[?principalId=='<old>'].id"
+// | xargs -n1 az role assignment delete --ids`) then re-run bootstrap.bicep.
 resource roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for roleId in roleIds: {
   name: guid(resourceGroup().id, mi.id, roleId)
   properties: {

--- a/infra/bicep/modules/key-vault-rbac.bicep
+++ b/infra/bicep/modules/key-vault-rbac.bicep
@@ -10,6 +10,7 @@ param keyVaultName string
 param principalIds array
 
 // Built-in role: Key Vault Secrets User
+// Reference: https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#key-vault-secrets-user
 var keyVaultSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
 
 resource kv 'Microsoft.KeyVault/vaults@2024-04-01-preview' existing = {

--- a/scripts/provision-apps.sh
+++ b/scripts/provision-apps.sh
@@ -173,6 +173,17 @@ WORKER_MI_JSON=$(jq -nc --arg k "$KITCHEN_MI" '{kitchenWorker: $k}')
 # Resolve the BFF MI clientId (appId of the apigateway's system-assigned MI service
 # principal). This is the FIC's `subject` claim. APIGATEWAY_MI is the MI's principalId
 # (objectId of the SP) — we need its appId.
+#
+# IMPORTANT: BFF_MI_CLIENT_ID must NEVER be passed as empty on a re-run after the
+# initial warm deploy. The FIC resource in modules/app-registrations.bicep depends
+# on this value as its 'subject'. If main.bicep is re-deployed with bffMiClientId=''
+# after the FIC has been created, the Microsoft.Graph extension will delete it,
+# causing the BFF to lose its trust relationship with its UAMI and break
+# SignedAssertionFromManagedIdentity for OBO/S2S until this script runs again.
+# The empty-string path is intentional ONLY on cold deploy (before APIGATEWAY_MI
+# resolves), and that path is not reached here because we already short-circuit
+# WHAT_IF on cold-env above; by the time we hit this line, APIGATEWAY_MI is set
+# and `az ad sp show` must succeed.
 BFF_MI_CLIENT_ID=$(az ad sp show --id "$APIGATEWAY_MI" --query appId -o tsv --only-show-errors)
 echo "    bff MI clientId = $BFF_MI_CLIENT_ID"
 


### PR DESCRIPTION
- azure.bicep: add explicit dependsOn:[keyVault, appInsights] on the
  acaStack module. The appInsights edge is technically redundant
  (caught by no-unnecessary-dependson) but the explicit listing is the
  intended documentation per mghabin/infra-engineering-guide ch02 §3
  ('explicit, reviewable composition'); the lint is suppressed inline
  with a rationale comment. The keyVault edge is genuinely missing.

- modules/aca-stack.bicep: tighten the docs around the positional
  ordering coupling between the services array and the services output
  map. Adds a top-of-section REQUIRED ORDER comment, expands the
  @description, and adds @metadata({requiredOrder, requiredLength,
  orderingConstraint}) so the constraint is visible at the param level.
  No structural rewrite (keyed-map output is out of scope for this PR).

- modules/app-registrations.bicep: top-of-file warning that
  bffMiClientId must never be empty on a re-run after the initial warm
  deploy or the FIC will be reconciled out of existence; rationale
  comment on the no-hardcoded-env-urls suppression for the Entra v2.0
  token endpoint issuer.

- modules/key-vault-rbac.bicep: docstring + Microsoft Learn link on the
  hardcoded Key Vault Secrets User role GUID.

- modules/cd-bootstrap.bicep: expand the UAMI delete+recreate gotcha
  comment with the concrete recovery steps (az role assignment delete
  by old principalId) and a pointer to operations.md.

- scripts/provision-apps.sh: mirror the FIC-empty-string warning at
  BFF_MI_CLIENT_ID resolution.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
