### PR TITLE
docs: add SCOPE, coverage-map, glossary, decision-trees + README reading-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com)
 
+## Read this first
+
+Before diving into the chapters, the four cross-cutting synthesis pages tell you whether this guide fits, what it covers, what every term means, and which decision lives where:
+
+- [`SCOPE.md`](SCOPE.md) — who this guide is for, who it isn't, and the explicit non-goals.
+- [`docs/decision-trees.md`](docs/decision-trees.md) — five Mermaid trees for the highest-leverage Entra decisions; entry point for the reading path.
+- [`coverage-map.md`](coverage-map.md) — exact ownership map: which doc owns which doctrine; siblings link, never re-decide.
+- [`glossary.md`](glossary.md) — every normatively-used term with a primary-source link.
+
 A working reference for **acquiring** and **validating** Microsoft Entra ID
 tokens in .NET 10 server-side apps. Covers app tokens (S2S / daemon) and
 user tokens (delegated / OBO) with the credential type that matters in
@@ -126,6 +135,8 @@ Who is calling?
         │   └── Use a Certificate on an app registration.               ← acceptable
         └── Last resort: Client Secret on an app registration.          ← avoid
 ```
+
+Full set of decision trees → [`docs/decision-trees.md`](docs/decision-trees.md).
 
 ## Library cheat-sheet
 

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -1,0 +1,142 @@
+# Scope — who this guide is for, and who it is not for
+
+This guide is opinionated.
+The opinions only hold inside a specific technical and organisational envelope.
+This page names that envelope so readers can decide, in 60 seconds, whether the rest of the guide will help them or mislead them.
+
+If your situation falls outside this envelope, individual chapters may still be useful as background — but the *defaults* will be wrong for you, and you should treat the recommendations as input, not verdict.
+
+The companion .NET engineering guide ([mghabin/dotnet-engineering-guide](https://github.com/mghabin/dotnet-engineering-guide)) owns the broader .NET 10 / ASP.NET Core / EF Core doctrine; this repo specialises that doctrine to **Microsoft Entra ID** authentication for server-side .NET ([learn.microsoft.com/entra/identity-platform/v2-overview](https://learn.microsoft.com/entra/identity-platform/v2-overview)).
+
+---
+
+## 1. Who it's for
+
+Concrete reader profiles.
+If two or more apply, you are the target reader.
+
+- A senior or staff .NET backend engineer owning one or more long-lived ASP.NET Core services on .NET 10 that authenticate against Microsoft Entra ID.
+- A solutions or application architect choosing the default token-acquisition library (Azure.Identity / MSAL.NET / Microsoft.Identity.Web) and the credential type (Managed Identity / Federated Identity Credential / certificate / secret) for a new bounded context ([learn.microsoft.com/entra/identity-platform/msal-overview](https://learn.microsoft.com/entra/identity-platform/msal-overview)).
+- A platform / SRE engineer standardising server-side Entra validation, app-registration shape, and credential rotation across **5 or more** services in the same tenant ([learn.microsoft.com/entra/identity-platform/quickstart-register-app](https://learn.microsoft.com/entra/identity-platform/quickstart-register-app)).
+- A staff engineer owning a shared `EntraAuth.*` library or "auth platform" and trying to stop every product team re-implementing JWT validation ([`docs/aks-shared-infra.md`](./docs/aks-shared-infra.md)).
+- An engineer wiring a new service that must call other services on behalf of a signed-in user (OBO) or as an app-only worker, and choosing where the credential lives ([`docs/acquisition.md`](./docs/acquisition.md)).
+- A security-minded reviewer enforcing the "no client secrets, no private keys on disk" baseline on Azure compute ([learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview)).
+
+---
+
+## 2. Organisational and technical shape it assumes
+
+The defaults assume a *cloud-native .NET shop* with at least one shared auth surface.
+Specifically:
+
+- **.NET 10 GA** on the current LTS / STS cadence; ASP.NET Core 10 with `Microsoft.Identity.Web` as the default JWT-bearer pipeline ([learn.microsoft.com/entra/identity-platform/microsoft-identity-web](https://learn.microsoft.com/entra/identity-platform/microsoft-identity-web), [github.com/AzureAD/microsoft-identity-web](https://github.com/AzureAD/microsoft-identity-web)).
+- **Microsoft Entra ID** (formerly Azure AD) as the workforce and workload identity provider; v2.0 endpoint for new app registrations ([learn.microsoft.com/entra/identity-platform/v2-overview](https://learn.microsoft.com/entra/identity-platform/v2-overview)).
+- **Azure as the deployment target.** Azure Container Apps, AKS, App Service, Azure Functions on the isolated worker model — anywhere Managed Identity is available ([learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview)).
+- **Multi-team estate**: at least 5 services, one shared auth library or platform team. Single-app shops can use the chapters but won't need [`docs/aks-shared-infra.md`](./docs/aks-shared-infra.md).
+- **Multi-tenant SaaS or B2B preferred.** Single-tenant guidance is called out where defaults differ ([learn.microsoft.com/entra/identity-platform/howto-convert-app-to-be-multi-tenant](https://learn.microsoft.com/entra/identity-platform/howto-convert-app-to-be-multi-tenant)).
+- **Engineering owns the app registrations.** App-reg lifecycle, role taxonomy, FIC creation, and rotation cadence are owned by the service team — not handed to a separate identity-ops group ([`docs/sample-setup.md`](./docs/sample-setup.md)).
+- **CI/CD via GitHub Actions** with OIDC into Azure (no stored client secrets in GitHub) ([learn.microsoft.com/entra/workload-id/workload-identity-federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)).
+
+---
+
+## 3. Who it's NOT for
+
+- **Authors of general OAuth 2.0 / OIDC tutorials.** This guide is Entra-specific; it cites RFC 6749 ([rfc-editor.org/rfc/rfc6749](https://www.rfc-editor.org/rfc/rfc6749)) and OIDC Core ([openid.net/specs/openid-connect-core-1_0.html](https://openid.net/specs/openid-connect-core-1_0.html)) as substrate, not as the topic.
+- **Consumer Microsoft account (MSA) developers.** The personal-account `consumers` authority and live.com sign-in patterns are out of scope ([learn.microsoft.com/entra/identity-platform/howto-convert-app-to-be-multi-tenant#who-can-sign-in-to-your-app](https://learn.microsoft.com/entra/identity-platform/howto-convert-app-to-be-multi-tenant)).
+- **On-prem IIS / .NET Framework legacy estates.** WS-Federation, WIF, and `System.IdentityModel` on full framework are not covered.
+- **Identity governance teams (IGA, access reviews, entitlement management).** That's [Microsoft Entra ID Governance](https://learn.microsoft.com/entra/id-governance/identity-governance-overview), a different product surface.
+- **Mobile-client auth engineers.** MSAL on iOS/Android, broker integration, and device-bound tokens are out of scope; MSAL.NET on a mobile target is mentioned only as background.
+- **Identity providers other than Entra ID.** Auth0, Okta, AWS Cognito, Google Identity, and Keycloak are not covered, even where the OIDC primitives overlap.
+
+---
+
+## 4. Explicit non-goals
+
+These are deliberately out of scope.
+Call them out so readers don't expect them.
+
+- **Not a UI / client-side guide.** Browser sign-in UX, MSAL.js, MSAL on mobile, and Blazor WebAssembly token flows are out of scope; the BFF in the sample uses server-side OIDC ([`docs/sample-setup.md`](./docs/sample-setup.md), [learn.microsoft.com/aspnet/core/blazor/security/server](https://learn.microsoft.com/aspnet/core/blazor/security/server)).
+- **Not an IdP implementation guide.** This guide consumes Entra; it does not document how to build one (no OpenIddict, no IdentityServer, no Keycloak deployment).
+- **Not Azure AD Connect / hybrid identity.** Directory sync, AD FS migration, password hash sync, and seamless SSO are out of scope ([learn.microsoft.com/entra/identity/hybrid](https://learn.microsoft.com/entra/identity/hybrid)).
+- **Not compliance mapping (FedRAMP / HIPAA / PCI-DSS / SOC 2).** The guide names the Entra-level controls; mapping them to a specific control framework is downstream.
+- **Not an Entra ID Governance manual.** Access reviews, entitlement management, lifecycle workflows, and PIM-for-groups are out of scope.
+- **Not a Microsoft Graph SDK tutorial.** Calling Graph from a .NET app appears only as an example consumer of a token; deep Graph guidance lives at [learn.microsoft.com/graph/sdks/sdks-overview](https://learn.microsoft.com/graph/sdks/sdks-overview).
+
+---
+
+## 5. "If you are X, this guide is Y for you"
+
+| Reader archetype | Recommendation |
+|---|---|
+| Staff .NET engineer at a 200-person SaaS, multi-team, cloud-native on Azure | **Primary reader.** Read [`docs/decision-trees.md`](./docs/decision-trees.md) → SCOPE → [`docs/matrix.md`](./docs/matrix.md) → [`docs/best-practices.md`](./docs/best-practices.md). |
+| Platform / auth-library owner (`EntraAuth.*` shared NuGet, multi-product) | **Primary reader.** Start at [`docs/aks-shared-infra.md`](./docs/aks-shared-infra.md), then [`docs/acquisition.md`](./docs/acquisition.md) and [`docs/validation.md`](./docs/validation.md). |
+| Architect picking credential type for a new service | **Primary reader.** [`docs/decision-trees.md`](./docs/decision-trees.md) Tree 2 + Tree 5 → [`docs/credential-patterns/index.md`](./docs/credential-patterns/index.md). |
+| Solo developer, one app, pre-PMF | **Skim only.** [`docs/run-locally.md`](./docs/run-locally.md) and [`docs/best-practices.md`](./docs/best-practices.md) are worth an hour; the platform / shared-infra chapters are premature. |
+| ASP.NET Core engineer needing JWT validation defaults only | **Targeted reader.** [`docs/validation.md`](./docs/validation.md) is the chapter; the rest is background. |
+| Mobile / SPA developer | **Wrong guide.** Read MSAL.js or MSAL mobile docs first; come back when you own a server-side .NET API. |
+| IGA / access-review engineer | **Wrong guide.** Use [Microsoft Entra ID Governance](https://learn.microsoft.com/entra/id-governance/identity-governance-overview); this guide is for app developers, not directory operators. |
+| Compliance / GRC reviewer mapping controls | **Reference, not source of truth.** Use this as the engineering-side counterpart to your control catalog; mapping work is yours. |
+
+---
+
+## 6. Reading paths
+
+Pick the path that matches why you opened the guide.
+Each path is ordered; do not skip steps.
+
+### 6.1 First 90 days on a new Entra-protected service
+
+- Start at [`docs/decision-trees.md`](./docs/decision-trees.md) — the synthesis entrypoint that routes you to the chapter that owns each decision.
+- Then this [`SCOPE.md`](./SCOPE.md) to confirm the envelope matches your situation.
+- Then [`docs/matrix.md`](./docs/matrix.md) for the scenario-by-scenario decision table.
+- Then [`docs/best-practices.md`](./docs/best-practices.md) as the one-page review card.
+- Then [`docs/acquisition.md`](./docs/acquisition.md) and [`docs/validation.md`](./docs/validation.md) for the load-bearing chapters.
+
+### 6.2 Deep-dive (read everything)
+
+- All of [`docs/`](./docs/) in the order listed in [`coverage-map.md`](./coverage-map.md): acquisition, validation, matrix, best-practices, credential-patterns, aks-shared-infra, sample-setup, run-locally, environments, deploy-cloud, operations.
+
+### 6.3 Implementer (running the sample)
+
+- [`docs/sample-setup.md`](./docs/sample-setup.md) — app registrations, role taxonomy, audience model.
+- [`docs/run-locally.md`](./docs/run-locally.md) — `az login` + `DefaultAzureCredential` against the cloud APIs.
+- [`docs/deploy-cloud.md`](./docs/deploy-cloud.md) — CI/CD, OIDC, image promotion, free-tier ACA deployment.
+- [`docs/operations.md`](./docs/operations.md) — what-if previews, branch-protection, "on fire" runbook.
+
+---
+
+## 7. Out-of-scope topics with redirects
+
+If your question lives in one of these areas, the right pointer is named below.
+
+- **Consumer Microsoft account (MSA) sign-in** → [Microsoft account documentation](https://learn.microsoft.com/entra/identity-platform/howto-convert-app-to-be-multi-tenant) and [the `consumers` authority](https://learn.microsoft.com/entra/identity-platform/v2-protocols).
+- **Identity governance, access reviews, entitlement management** → [Microsoft Entra ID Governance](https://learn.microsoft.com/entra/id-governance/identity-governance-overview).
+- **Hybrid identity, AD FS, Azure AD Connect** → [Microsoft Entra hybrid identity](https://learn.microsoft.com/entra/identity/hybrid).
+- **MSAL on mobile / SPA / desktop clients** → [MSAL overview](https://learn.microsoft.com/entra/identity-platform/msal-overview) and per-platform MSAL docs.
+- **Microsoft Graph API surface** → [Microsoft Graph documentation](https://learn.microsoft.com/graph/overview).
+- **Conditional Access policy authoring** (admin side) → [Conditional Access documentation](https://learn.microsoft.com/entra/identity/conditional-access/overview); this guide only covers the *app-side* CAE / claims-challenge contract ([`docs/validation.md`](./docs/validation.md) §6).
+- **PIM, privileged role assignments** → [Microsoft Entra Privileged Identity Management](https://learn.microsoft.com/entra/id-governance/privileged-identity-management/pim-configure).
+- **B2C / External Identities / CIAM** → [Microsoft Entra External ID](https://learn.microsoft.com/entra/external-id/external-identities-overview); the workforce-tenant patterns here partially apply but the policy / branding surface is different.
+- **General .NET / ASP.NET Core / EF Core doctrine** → [`mghabin/dotnet-engineering-guide`](https://github.com/mghabin/dotnet-engineering-guide). Auth-policy shape (delegated vs app-only) lives in [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz) and is mirrored here.
+
+---
+
+## 8. Maintenance posture
+
+- **Targets the current GA Entra v2.0 endpoint and Microsoft.Identity.Web on .NET 10.** When .NET 11 ships, guidance moves with it; the previous LTS is called out inline only where defaults differ.
+- **Pre-GA features are labeled.** Anything in preview (CAE preview surfaces, ACRS preview) is marked `preview` inline and is not a default.
+- **Citations are primary-source.** Microsoft Learn (`learn.microsoft.com/entra/*`), the IETF RFCs ([6749](https://www.rfc-editor.org/rfc/rfc6749), [7519](https://www.rfc-editor.org/rfc/rfc7519), [8693](https://www.rfc-editor.org/rfc/rfc8693)), the [OIDC Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) spec, and the official Microsoft GitHub repos for [Microsoft.Identity.Web](https://github.com/AzureAD/microsoft-identity-web), [MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet), and [Azure SDK / Azure.Identity](https://github.com/Azure/azure-sdk-for-net) are the only acceptable sources for a normative claim.
+- **No Medium posts, random blogs, or YouTube** count as a primary source.
+
+---
+
+## Sources
+
+- Microsoft identity platform overview — [learn.microsoft.com/entra/identity-platform/v2-overview](https://learn.microsoft.com/entra/identity-platform/v2-overview)
+- Managed identities for Azure resources — [learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview)
+- Workload identity federation — [learn.microsoft.com/entra/workload-id/workload-identity-federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+- Microsoft.Identity.Web — [learn.microsoft.com/entra/identity-platform/microsoft-identity-web](https://learn.microsoft.com/entra/identity-platform/microsoft-identity-web), [github.com/AzureAD/microsoft-identity-web](https://github.com/AzureAD/microsoft-identity-web)
+- MSAL.NET — [learn.microsoft.com/entra/identity-platform/msal-overview](https://learn.microsoft.com/entra/identity-platform/msal-overview), [github.com/AzureAD/microsoft-authentication-library-for-dotnet](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet)
+- RFC 6749 — The OAuth 2.0 Authorization Framework — [rfc-editor.org/rfc/rfc6749](https://www.rfc-editor.org/rfc/rfc6749)
+- RFC 7519 — JSON Web Token (JWT) — [rfc-editor.org/rfc/rfc7519](https://www.rfc-editor.org/rfc/rfc7519)
+- OpenID Connect Core 1.0 — [openid.net/specs/openid-connect-core-1_0.html](https://openid.net/specs/openid-connect-core-1_0.html)

--- a/coverage-map.md
+++ b/coverage-map.md
@@ -1,0 +1,91 @@
+<!-- markdownlint-disable MD024 -->
+# Coverage map — who owns what across the Entra auth guide
+
+Companion to [`README.md`](./README.md), [`SCOPE.md`](./SCOPE.md), and [`docs/best-practices.md`](./docs/best-practices.md).
+Every concept is owned by exactly one chapter.
+Sibling chapters reference (link) the owner; they do not re-decide.
+This page is the master "who owns what" matrix — if two chapters look like they overlap, the [conflict-resolution](#conflict-resolution) rule names the owner.
+
+Primary sources for ownership: the chapters themselves under [`docs/`](./docs/), [Microsoft.Identity.Web](https://learn.microsoft.com/entra/identity-platform/microsoft-identity-web), [Microsoft Entra app roles](https://learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps), and the underlying [Microsoft identity platform](https://learn.microsoft.com/entra/identity-platform/v2-overview) docs.
+
+---
+
+## Conflict resolution
+
+- If two chapters appear to overlap, the **acquisition / validation pair owns the protocol surface**, and the **operational chapters own the deployment surface**.
+- Example: [`acquisition.md`](./docs/acquisition.md) owns the *credential picker for token requests*; [`credential-patterns/`](./docs/credential-patterns/) owns the *credential type itself* (MI vs FIC vs cert vs secret). Acquisition links to credential-patterns, never re-derives it.
+- Example: [`validation.md`](./docs/validation.md) owns *how a server validates a JWT*; [`best-practices.md`](./docs/best-practices.md) restates the rule in checklist form but never adds new doctrine.
+- Example: [`matrix.md`](./docs/matrix.md) owns the *scenario-by-scenario picker*; it links to acquisition / validation / credential-patterns and never re-decides any cell.
+- Example: [`sample-setup.md`](./docs/sample-setup.md) owns *this sample's* app registrations and role taxonomy; [`deploy-cloud.md`](./docs/deploy-cloud.md) owns *how those registrations get into dev / ppe / prod*.
+- A chapter may **demonstrate** a deferred concept in a code sample, but it must not redefine the rule. The rule lives in the owner.
+
+---
+
+## Ownership matrix
+
+One row per concept. The Owner is the single source of truth; siblings link, never re-decide.
+
+| Concept | Owner | Sibling references |
+|---|---|---|
+| App tokens (S2S / daemon) — `client_credentials`, MI, FIC, cert, secret | [`acquisition.md`](./docs/acquisition.md) §1 | [`matrix.md`](./docs/matrix.md), [`credential-patterns/index.md`](./docs/credential-patterns/index.md), [`best-practices.md`](./docs/best-practices.md) |
+| User tokens (delegated) — auth-code + PKCE on the client, validation on the API | [`acquisition.md`](./docs/acquisition.md) §2 | [`validation.md`](./docs/validation.md), [`matrix.md`](./docs/matrix.md) |
+| On-Behalf-Of (OBO) flow | [`acquisition.md`](./docs/acquisition.md) §2b | [`matrix.md`](./docs/matrix.md), [`sample-setup.md`](./docs/sample-setup.md) |
+| Token caching (MSAL / Microsoft.Identity.Web in-memory + distributed) | [`acquisition.md`](./docs/acquisition.md) | [`best-practices.md`](./docs/best-practices.md), [`aks-shared-infra.md`](./docs/aks-shared-infra.md) |
+| Library picks: Azure.Identity vs MSAL.NET vs Microsoft.Identity.Web | [`acquisition.md`](./docs/acquisition.md) §1e | [`README.md`](./README.md) cheat-sheet, [`matrix.md`](./docs/matrix.md) |
+| JWT signature, audience, issuer, lifetime validation | [`validation.md`](./docs/validation.md) §1 | [`best-practices.md`](./docs/best-practices.md), [`matrix.md`](./docs/matrix.md) |
+| `scp` (delegated scope) vs `roles` (app role) split | [`validation.md`](./docs/validation.md) §2 | [`matrix.md`](./docs/matrix.md), [`best-practices.md`](./docs/best-practices.md), dotnet-guide [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz) |
+| v1 vs v2 audiences, token-version detection | [`validation.md`](./docs/validation.md) §3 | [`acquisition.md`](./docs/acquisition.md), [`sample-setup.md`](./docs/sample-setup.md) |
+| Multi-tenant `IssuerValidator` (`AadIssuerValidator`) + `tid` allow-list | [`validation.md`](./docs/validation.md) §3 | [`best-practices.md`](./docs/best-practices.md), [`matrix.md`](./docs/matrix.md) |
+| App-token `azp` / `appid` allow-list (per-client gate) | [`validation.md`](./docs/validation.md) §4 | [`best-practices.md`](./docs/best-practices.md), dotnet-guide [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz) |
+| CAE (Continuous Access Evaluation) and ACRS (claims challenges) wiring | [`validation.md`](./docs/validation.md) §6 | [`best-practices.md`](./docs/best-practices.md) |
+| One-page numbered checklist (distillation only; no new doctrine) | [`best-practices.md`](./docs/best-practices.md) | [`README.md`](./README.md), [`matrix.md`](./docs/matrix.md) |
+| Scenario-by-scenario decision table | [`matrix.md`](./docs/matrix.md) | All other chapters link here for "which scenario am I in?" |
+| Credential picker (MI / FIC / cert / secret) | [`credential-patterns/index.md`](./docs/credential-patterns/index.md) | [`acquisition.md`](./docs/acquisition.md), [`matrix.md`](./docs/matrix.md), [`best-practices.md`](./docs/best-practices.md) |
+| Managed Identity — UAMI vs SAMI, IMDS endpoint, `DefaultAzureCredential` | [`credential-patterns/managed-identity.md`](./docs/credential-patterns/managed-identity.md) | [`acquisition.md`](./docs/acquisition.md), [`run-locally.md`](./docs/run-locally.md), [`deploy-cloud.md`](./docs/deploy-cloud.md) |
+| Federated Identity Credential (FIC), RFC 8693 Token Exchange, GitHub OIDC subject pinning, `SignedAssertionFromManagedIdentity` (clarified as **not** OIDC-FIC) | [`credential-patterns/federated-identity.md`](./docs/credential-patterns/federated-identity.md) | [`deploy-cloud.md`](./docs/deploy-cloud.md), [`sample-setup.md`](./docs/sample-setup.md), [`acquisition.md`](./docs/acquisition.md) |
+| Certificate credential — when acceptable, `EphemeralKeySet`, rotation cadence | [`credential-patterns/cert.md`](./docs/credential-patterns/cert.md) | [`best-practices.md`](./docs/best-practices.md), [`matrix.md`](./docs/matrix.md) |
+| Client secret — anti-pattern + the three documented exceptions | [`credential-patterns/client-secret.md`](./docs/credential-patterns/client-secret.md) | [`best-practices.md`](./docs/best-practices.md), [`matrix.md`](./docs/matrix.md) |
+| Shared platform doctrine for N services × M products on AKS | [`aks-shared-infra.md`](./docs/aks-shared-infra.md) | [`SCOPE.md`](./SCOPE.md), [`best-practices.md`](./docs/best-practices.md) |
+| This sample's app registrations, role taxonomy, audience model | [`sample-setup.md`](./docs/sample-setup.md) | [`run-locally.md`](./docs/run-locally.md), [`deploy-cloud.md`](./docs/deploy-cloud.md), [`acquisition.md`](./docs/acquisition.md) |
+| CI/CD, image promotion by SHA, per-env provisioning | [`deploy-cloud.md`](./docs/deploy-cloud.md) | [`environments.md`](./docs/environments.md), [`operations.md`](./docs/operations.md) |
+| Operations runbook — what-if previews, branch protection, env teardown, "on fire" | [`operations.md`](./docs/operations.md) | [`deploy-cloud.md`](./docs/deploy-cloud.md), [`environments.md`](./docs/environments.md) |
+| Local development — `az login` + `DefaultAzureCredential`, OIDC sign-in browser flow | [`run-locally.md`](./docs/run-locally.md) | [`sample-setup.md`](./docs/sample-setup.md), [`credential-patterns/managed-identity.md`](./docs/credential-patterns/managed-identity.md) |
+| Promotion model (dev → ppe → prod), per-env config, production guardrails | [`environments.md`](./docs/environments.md) | [`deploy-cloud.md`](./docs/deploy-cloud.md), [`operations.md`](./docs/operations.md) |
+
+---
+
+## Cross-cutting concerns and their owner chapter
+
+When a topic surfaces in more than one chapter, exactly one chapter owns it.
+The others reference; they do not re-decide.
+
+| Concern | Owner | Why it lives there |
+|---|---|---|
+| Auth policy shape (delegated `scp` vs app-only `roles` + `azp`) | [`validation.md`](./docs/validation.md) §2 + §4 | The validation pipeline is where the policy is enforced; mirrors dotnet-guide [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz). |
+| Multi-tenant validation (`organizations` authority + `IssuerValidator` + `tid` allow-list) | [`validation.md`](./docs/validation.md) §3 | Single decision point; both signature and tenant gating are here. |
+| Credential type per host (Azure compute → MI; OIDC issuer → FIC; portable hardware → cert) | [`credential-patterns/index.md`](./docs/credential-patterns/index.md) | The picker is the single owner; per-credential pages own the *how*. |
+| `SignedAssertionFromManagedIdentity` (BFF token-exchange) — **not** OIDC-FIC | [`credential-patterns/federated-identity.md`](./docs/credential-patterns/federated-identity.md) | Same chapter as FIC but explicitly disambiguates the two — mistaking them swaps the credential model. |
+| Token cache backing store (in-memory vs distributed Redis vs SQL) | [`acquisition.md`](./docs/acquisition.md) | The cache is part of how a token is acquired; sibling chapters link here. |
+| App registration shape, audience, role taxonomy for *this sample* | [`sample-setup.md`](./docs/sample-setup.md) | Sample-specific; the doctrine for "what an app reg should look like in general" lives in [`acquisition.md`](./docs/acquisition.md) and [`validation.md`](./docs/validation.md). |
+| Per-env app-reg provisioning and FIC creation in CI | [`deploy-cloud.md`](./docs/deploy-cloud.md) | Operational; the *credential type* doctrine is owned by credential-patterns. |
+| Local dev credential model (`DefaultAzureCredential` chain) | [`run-locally.md`](./docs/run-locally.md) | Operational; the *credential type* doctrine is owned by credential-patterns. |
+
+---
+
+## Rule
+
+> Every doctrine bullet appears in exactly one owner; siblings link, never re-decide.
+
+If you find yourself writing the same `must` / `should` / `avoid` rule in two chapters, one of them is wrong.
+Open a PR that deletes the duplicate and replaces it with a link to the owner.
+
+---
+
+## Sources
+
+- Microsoft.Identity.Web — [learn.microsoft.com/entra/identity-platform/microsoft-identity-web](https://learn.microsoft.com/entra/identity-platform/microsoft-identity-web)
+- Microsoft.Identity.Web (repo + samples) — [github.com/AzureAD/microsoft-identity-web](https://github.com/AzureAD/microsoft-identity-web)
+- Add app roles to your application — [learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps](https://learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps)
+- Access token claims reference — [learn.microsoft.com/entra/identity-platform/access-token-claims-reference](https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference)
+- ID token claims reference — [learn.microsoft.com/entra/identity-platform/id-token-claims-reference](https://learn.microsoft.com/entra/identity-platform/id-token-claims-reference)
+- Microsoft identity platform overview — [learn.microsoft.com/entra/identity-platform/v2-overview](https://learn.microsoft.com/entra/identity-platform/v2-overview)

--- a/docs/acquisition.md
+++ b/docs/acquisition.md
@@ -45,7 +45,7 @@ var token = await new ManagedIdentityCredential()
 
 Notes:
 - MI is **system-assigned** (lifecycle tied to resource) or **user-assigned** (portable; preferred for shared infra and blue/green).
-- MI tokens are issued by `https://login.microsoftonline.com/<tenant>/` with `appid` of the MI's service principal — see [validation](validation.md#mi-tokens).
+- MI tokens are issued by `https://login.microsoftonline.com/<tenant>/` with `appid` of the MI's service principal — see [validation](validation.md#5-mi-tokens).
 - MI cannot do OBO. MI cannot represent a user.
 
 ### 1b. Workload Identity Federation (FIC) — preferred outside Azure

--- a/docs/decision-trees.md
+++ b/docs/decision-trees.md
@@ -1,0 +1,142 @@
+# Decision Trees — Entra Auth One-Hour Synthesis
+
+This file summarises and routes; canonical wording lives in [`../docs/`](../docs/) (acquisition, validation, credential-patterns) and in the dotnet-engineering-guide [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz).
+Where this file and a chapter disagree, the chapter wins.
+
+This page collects the highest-leverage decisions a .NET / platform engineer actually makes when designing or reviewing a Microsoft Entra ID integration on a new or migrating server-side service.
+Each tree gives the trigger, the cost of the wrong call, the Mermaid flow, and a pointer back to the owning chapter — go there before you argue with the tree.
+
+---
+
+## 1. Who is calling? — user token + OBO vs app token
+
+- Trigger: a new endpoint, or a new outbound call from a service to another Entra-protected API.
+- Cost of wrong call: a daemon that ships a user's refresh token (no user is present, the token will expire and the worker will silently break); or a user-facing endpoint that demands an app-only token (every interactive call now needs an app reg per browser, which doesn't make sense).
+- Default per [`acquisition.md`](../docs/acquisition.md): if a *user* is on the wire, acquire a delegated user token on the client (auth-code + PKCE) and use *OBO* on the middle tier. If no user is on the wire, acquire an app-only token via `client_credentials`.
+
+```mermaid
+flowchart TD
+    A[New call to Entra-protected API] --> B{Is a signed-in user on the wire?}
+    B -->|Yes, interactive client → API| C[Delegated USER token<br/>auth-code + PKCE on the client — acquisition.md §2]
+    C --> D{This API needs to call<br/>a downstream API as the user?}
+    D -->|Yes| E[On-Behalf-Of OBO<br/>middle tier exchanges user token — acquisition.md §2b]
+    D -->|No| F[Validate user token<br/>scp + audience — validation.md §2]
+    B -->|No, daemon / worker / cron| G[App-only token<br/>client_credentials — acquisition.md §1]
+    G --> H[Validate app token<br/>roles + azp allow-list — validation.md §4]
+```
+
+References: [`docs/acquisition.md#1-app-tokens-s2s-daemons-workers`](../docs/acquisition.md#1-app-tokens-s2s-daemons-workers), [`docs/acquisition.md#2-user-tokens-delegated`](../docs/acquisition.md#2-user-tokens-delegated), [`docs/acquisition.md#2b-calling-a-downstream-api-as-that-user-obo`](../docs/acquisition.md#2b-calling-a-downstream-api-as-that-user-obo).
+
+---
+
+## 2. Where does the workload run? — credential type per host
+
+- Trigger: a new deployable that needs to acquire an Entra token.
+- Cost of wrong call: a client secret in App Service config that nobody rotates; a cert on disk on a node that nobody pinned the rotation cadence on; or burning a week wiring a Service Principal password into GitHub Actions when *FIC* would have removed the secret entirely.
+- Default per [`credential-patterns/index.md`](../docs/credential-patterns/index.md): on Azure compute, *Managed Identity*. On a non-Azure platform that issues OIDC tokens (GitHub Actions, GitLab, Kubernetes), *Federated Identity Credential*. On a portable host with a hardware credential, certificate. Client secret only as a documented exception.
+
+```mermaid
+flowchart TD
+    A[New workload acquiring an Entra token] --> B{Where does it run?}
+    B -->|Azure compute<br/>App Service / ACA / AKS / VM / Functions| C[Managed Identity — credential-patterns/managed-identity.md]
+    B -->|GitHub Actions / GitLab CI / K8s SA<br/>OIDC issuer available| D[Federated Identity Credential FIC — credential-patterns/federated-identity.md]
+    B -->|Other cloud / on-prem / portable| E{Hardware-protected<br/>cert available?}
+    E -->|Yes| F[Certificate credential — credential-patterns/cert.md]
+    E -->|No| G[Client secret — last resort<br/>document the exception<br/>rotate aggressively — credential-patterns/client-secret.md]
+```
+
+References: [`docs/credential-patterns/index.md#decision-matrix`](../docs/credential-patterns/index.md#decision-matrix), [`docs/credential-patterns/managed-identity.md`](../docs/credential-patterns/managed-identity.md), [`docs/credential-patterns/federated-identity.md`](../docs/credential-patterns/federated-identity.md), [`docs/credential-patterns/cert.md`](../docs/credential-patterns/cert.md), [`docs/credential-patterns/client-secret.md`](../docs/credential-patterns/client-secret.md).
+
+---
+
+## 3. Single-tenant or multi-tenant API?
+
+- Trigger: standing up a new Entra-protected API and choosing the audience model.
+- Cost of wrong call: a single-tenant API that silently accepts tokens from any tenant because validation defaults to "trust the issuer Entra hands me"; or a multi-tenant API that crashes at first foreign-tenant sign-in because `IssuerValidator` was never configured.
+- Default per [`validation.md`](../docs/validation.md) §3: if you serve exactly one tenant, pin `TenantId` to that GUID. If you serve more than one, set `TenantId="organizations"`, register `AadIssuerValidator`, and gate on a `tid` allow-list. **Never** accept `common` without a `tid` allow-list — `common` permits personal Microsoft accounts unless the app reg's `signInAudience` excludes them.
+
+```mermaid
+flowchart TD
+    A[New Entra-protected API] --> B{One tenant or many?}
+    B -->|Exactly one tenant| C[Pin TenantId to the tenant GUID<br/>default JwtBearer validation is enough — validation.md §3]
+    B -->|More than one tenant| D[TenantId = organizations<br/>+ register AadIssuerValidator<br/>+ tid allow-list — validation.md §3]
+    D --> E{New tenant onboards?}
+    E -->|Yes| F[Add tid to allow-list<br/>require admin consent in the new tenant — validation.md §3]
+    E -->|No| G[Reject token<br/>HTTP 401 with diagnostic — validation.md §3]
+```
+
+References: [`docs/validation.md#3-issuer-audience-v1-vs-v2-single-vs-multi-tenant`](../docs/validation.md#3-issuer-audience-v1-vs-v2-single-vs-multi-tenant).
+
+---
+
+## 4. Does this endpoint accept delegated, app-only, or both?
+
+- Trigger: protecting a new endpoint that may be hit by signed-in users (`scp`), app-only callers (`roles` + `azp`), or both.
+- Cost of wrong call: a single OR-claims policy that lets an app-only token reach a user-only endpoint (no `azp` allow-list, no `scp` check), or a user token satisfy an app-only endpoint by carrying an unrelated `scp`. Both are real privilege-escalation bugs in production APIs. Mirrors dotnet-guide [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz).
+- Default per [`validation.md`](../docs/validation.md) §4 + dotnet-guide ch02 §10: **two separate named policies on two separate authorisation attributes**, never an OR-claims policy. Delegated → `[Authorize] + [RequiredScope("orders.read")]`. App-only → `[Authorize(Roles="Orders.Process")] + RequireClientApp` (azp allow-list). Both → list both attributes; each enforces its own invariants.
+
+```mermaid
+flowchart TD
+    A[New protected endpoint] --> B{Caller identity model?}
+    B -->|Delegated user only| C["[Authorize] + [RequiredScope(scope)]<br/>reject if roles present without scp — validation.md §4"]
+    B -->|App-only / daemon only| D["[Authorize(Roles=app-role)]<br/>+ RequireClientApp azp allow-list<br/>+ reject if scp present — validation.md §4"]
+    B -->|Both flows in scope| E[Two separate named policies<br/>on two separate authorizations<br/>NEVER one OR-claims policy — validation.md §4]
+    C --> F[Each request: presence of scp<br/>+ specific scope value — validation.md §4]
+    D --> G[Each request: presence of roles<br/>+ azp / appid in allow-list<br/>+ absence of scp — validation.md §4]
+    E --> H[Document which paths each flow may reach;<br/>each policy enforces its own invariants — validation.md §4]
+```
+
+References: [`docs/validation.md#4-app-token-specific-checks`](../docs/validation.md#4-app-token-specific-checks), dotnet-engineering-guide [`docs/02-aspnetcore.md#10-authnauthz`](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz).
+
+---
+
+## 5. Can you use MI / FIC, or do you need cert / secret?
+
+- Trigger: revisiting credential type during a credential-rotation event, a new environment, or an architecture review.
+- Cost of wrong call: shipping a client secret to a workload that *could* use Managed Identity ("we'll fix it later" never happens); or putting a long-lived cert on a Container App that can do MI for free.
+- Default per [`credential-patterns/index.md`](../docs/credential-patterns/index.md): MI on Azure compute. FIC if an OIDC issuer exists on the platform. Cert if you must run somewhere with a hardware-protected key store. Secret only as a written, rotated, time-boxed exception.
+
+```mermaid
+flowchart TD
+    A[Need to authenticate as an app] --> B{On Azure compute?}
+    B -->|Yes| C[Managed Identity UAMI<br/>preferred over SAMI in shared infra — credential-patterns/managed-identity.md]
+    B -->|No| D{Platform issues OIDC tokens?<br/>GitHub Actions / GitLab / K8s SA}
+    D -->|Yes| E[Federated Identity Credential FIC<br/>RFC 8693 token exchange — credential-patterns/federated-identity.md]
+    D -->|No| F{Hardware-protected key<br/>HSM / TPM / smart card?}
+    F -->|Yes| G[Certificate credential<br/>EphemeralKeySet, rotation cadence — credential-patterns/cert.md]
+    F -->|No| H[Client secret — last resort<br/>three documented exceptions only<br/>rotate aggressively — credential-patterns/client-secret.md]
+    C --> I{BFF that mints<br/>client_assertion via MI?}
+    I -->|Yes| J["SignedAssertionFromManagedIdentity<br/>NOT OIDC-FIC — different mechanism — credential-patterns/federated-identity.md"]
+    I -->|No| K[Done — credential-patterns/managed-identity.md]
+```
+
+References: [`docs/credential-patterns/index.md#decision-matrix`](../docs/credential-patterns/index.md#decision-matrix), [`docs/credential-patterns/managed-identity.md`](../docs/credential-patterns/managed-identity.md), [`docs/credential-patterns/federated-identity.md`](../docs/credential-patterns/federated-identity.md), [`docs/credential-patterns/cert.md`](../docs/credential-patterns/cert.md), [`docs/credential-patterns/client-secret.md`](../docs/credential-patterns/client-secret.md).
+
+---
+
+## Closing rule
+
+Every tree above picks a side.
+Disagree by reading the cited chapter and finding a different rule there — not by adding a branch.
+This page is synthesis, not a menu.
+
+Cross-links to companion guides:
+
+- General .NET auth-policy doctrine (delegated vs app-only, no OR-claims policies) — dotnet-engineering-guide [`docs/02-aspnetcore.md#10-authnauthz`](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz).
+- Workload identity at the infrastructure layer (no static credentials, OIDC from CI, SPIFFE comparison) — infra-engineering-guide [`docs/06-security-supply-chain.md#3-workload-identity--the-no-static-credentials-rule`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/06-security-supply-chain.md#3-workload-identity--the-no-static-credentials-rule).
+
+---
+
+## Sources
+
+- Microsoft identity platform overview — [learn.microsoft.com/entra/identity-platform/v2-overview](https://learn.microsoft.com/entra/identity-platform/v2-overview)
+- Access token claims reference — [learn.microsoft.com/entra/identity-platform/access-token-claims-reference](https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference)
+- On-Behalf-Of flow — [learn.microsoft.com/entra/identity-platform/v2-oauth2-on-behalf-of-flow](https://learn.microsoft.com/entra/identity-platform/v2-oauth2-on-behalf-of-flow)
+- Managed identities for Azure resources — [learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview)
+- Workload identity federation — [learn.microsoft.com/entra/workload-id/workload-identity-federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+- Microsoft.Identity.Web — multi-tenant web APIs — [github.com/AzureAD/microsoft-identity-web/wiki/multi-tenant-web-apis](https://github.com/AzureAD/microsoft-identity-web/wiki/multi-tenant-web-apis)
+- App roles — [learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps](https://learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps)
+- RFC 6749 — The OAuth 2.0 Authorization Framework — [rfc-editor.org/rfc/rfc6749](https://www.rfc-editor.org/rfc/rfc6749)
+- RFC 7519 — JSON Web Token (JWT) — [rfc-editor.org/rfc/rfc7519](https://www.rfc-editor.org/rfc/rfc7519)
+- RFC 8693 — OAuth 2.0 Token Exchange — [rfc-editor.org/rfc/rfc8693](https://www.rfc-editor.org/rfc/rfc8693)
+- OpenID Connect Core 1.0 — [openid.net/specs/openid-connect-core-1_0.html](https://openid.net/specs/openid-connect-core-1_0.html)

--- a/glossary.md
+++ b/glossary.md
@@ -1,0 +1,213 @@
+# Glossary
+
+This glossary defines the terms used across the Entra Auth Patterns guide.
+Definitions are opinionated: where the Entra / OAuth ecosystem uses a term inconsistently, the entry calls out the disambiguation and pins this guide to a specific primary source.
+Citations point at primary sources (Microsoft Learn, IETF RFCs, the OpenID Connect Core spec, the official Microsoft GitHub repos for Microsoft.Identity.Web / MSAL.NET / Azure SDK) — not at blog summaries.
+
+**Terms with strong opinions in this guide** (read these entries carefully): *azp*, *appid*, *roles*, *scp*, *DefaultAzureCredential*, *Federated Identity Credential*, *SignedAssertionFromManagedIdentity* (often confused with FIC), *IssuerValidator*, *v1 vs v2 token*.
+
+**Deprecated or to-be-avoided in new work**: client secrets on app registrations (use *Managed Identity* or *Federated Identity Credential* instead), v1.0 endpoint for new app registrations (use v2.0), `idtyp` checks as a substitute for the *roles* + *azp* allow-list (the substitution is unsafe).
+
+---
+
+## A
+
+### ACRS (Authentication Context Class Reference Set)
+
+Microsoft Entra mechanism that lets a resource API demand a *Conditional Access* authentication context (e.g., MFA, compliant device) from the caller via a `claims` challenge. The API returns a 401 with a `WWW-Authenticate: Bearer claims="…"` header carrying the required `acrs` value; the client re-acquires a token with the satisfied claim. Owned in [`docs/validation.md`](./docs/validation.md) §6. [Conditional Access — auth context](https://learn.microsoft.com/entra/identity/conditional-access/concept-conditional-access-cloud-apps#authentication-context).
+
+### app-only token / application permission
+
+A token issued via the OAuth 2.0 *client_credentials* grant ([RFC 6749 §4.4](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)) that represents the *application itself*, not a signed-in user. Carries `roles` (app role) and `azp` (authorized party); **no** `scp` claim. Permissions are "Application permissions" in the Entra app-registration UI and require admin consent. [Microsoft identity platform — application permissions](https://learn.microsoft.com/entra/identity-platform/permissions-consent-overview).
+
+### appid (claim, v1.0)
+
+The Entra v1.0-token claim identifying the **client application** that obtained the token. Equivalent to *azp* in v2.0 tokens. Use *appid* / *azp* — not *scp* or *roles* — to gate per-client policy. [Access token claims reference](https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference).
+
+### Azure.Identity
+
+The Azure SDK package (`Azure.Identity`, [github.com/Azure/azure-sdk-for-net](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity)) that exposes `TokenCredential` implementations (`ManagedIdentityCredential`, `WorkloadIdentityCredential`, `ClientCertificateCredential`, *DefaultAzureCredential*, …) for calling **Azure resources** (Storage, Key Vault, Cosmos, Service Bus). Not for arbitrary OAuth flows; does not implement *OBO*. [Azure.Identity overview](https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme).
+
+### azp (Authorized Party claim)
+
+The OIDC standard claim ([OpenID Connect Core §2](https://openid.net/specs/openid-connect-core-1_0.html#IDToken)) carrying the **client_id of the application** the token was issued to. In Entra v2.0 tokens it identifies the calling app; combined with *roles* it forms the per-client allow-list pattern in [`docs/validation.md`](./docs/validation.md) §4. v1.0-token equivalent is *appid*. [Access token claims reference](https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference).
+
+---
+
+## B
+
+### BFF (Backend-for-Frontend)
+
+Server-side façade that performs the OIDC sign-in on behalf of a browser SPA, holds the user's refresh token in a server-side cache, and brokers downstream API calls (often via *OBO*). In this sample, `Ftgo.ApiGateway` is the BFF. Pattern named in Sam Newman's *Building Microservices* and called out by Microsoft as the recommended browser-app shape. [Microsoft identity platform — BFF pattern](https://learn.microsoft.com/azure/architecture/patterns/backends-for-frontends).
+
+---
+
+## C
+
+### CAE (Continuous Access Evaluation)
+
+Entra mechanism that lets a resource API revoke or re-validate a token between issuance and expiry by responding 401 with a `claims` challenge; the client re-acquires a CAE-aware token. Long-lived (24h) tokens become safe because revocation is near-real-time. Owned in [`docs/validation.md`](./docs/validation.md) §6. [Continuous access evaluation](https://learn.microsoft.com/entra/identity/conditional-access/concept-continuous-access-evaluation).
+
+### Conditional Access
+
+Entra policy engine that evaluates signals (user, device, location, risk, app) at sign-in time and during *CAE* re-evaluation, then grants, blocks, or steps up the session (MFA, compliant device). App developers consume CA via *ACRS* claims challenges; CA *authoring* is out of scope for this guide. [Conditional Access overview](https://learn.microsoft.com/entra/identity/conditional-access/overview).
+
+### consent (admin vs user)
+
+The Entra step where a tenant authorises an app to receive specific permissions. **User consent** is per-user and limited to delegated permissions the tenant marks as user-consentable; **admin consent** is tenant-wide and required for application permissions and any admin-only scopes. Multi-tenant apps require admin consent in each tenant before any non-trivial scope works. [Permissions and consent overview](https://learn.microsoft.com/entra/identity-platform/permissions-consent-overview).
+
+---
+
+## D
+
+### DefaultAzureCredential
+
+`Azure.Identity` chained `TokenCredential` that tries, in order: environment variables, *Workload Identity*, *Managed Identity*, Visual Studio / VS Code, Azure CLI, Azure PowerShell, IntelliJ, interactive browser. Default for *calling Azure resources* in this sample; in local dev it falls through to `az login`. [DefaultAzureCredential reference](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential).
+
+### delegated permission
+
+A permission granted to an app to act *on behalf of a signed-in user*. Surfaces in the access token as the *scp* claim (space-separated scopes). Contrast with *application permission* (which surfaces as *roles*). [Permissions and consent overview](https://learn.microsoft.com/entra/identity-platform/permissions-consent-overview).
+
+---
+
+## E
+
+### Entra ID (formerly Azure AD)
+
+Microsoft's cloud identity provider. Renamed from "Azure Active Directory" in July 2023; the OIDC / OAuth 2.0 endpoints and tokens are unchanged. v2.0 endpoint is the default for new app registrations. [Microsoft identity platform overview](https://learn.microsoft.com/entra/identity-platform/v2-overview), [Azure AD → Microsoft Entra ID rename](https://learn.microsoft.com/entra/fundamentals/new-name).
+
+---
+
+## F
+
+### Federated Identity Credential (FIC)
+
+Entra app-registration credential type that lets an external OIDC issuer (GitHub Actions, GitLab, Kubernetes service accounts, another Entra tenant) mint tokens that Entra accepts in place of a client secret or certificate, via [RFC 8693 OAuth 2.0 Token Exchange](https://www.rfc-editor.org/rfc/rfc8693). Default credential model for non-Azure compute. Configured under **Certificates & secrets → Federated credentials** on the app reg. [Workload identity federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation), [Configure a federated identity credential](https://learn.microsoft.com/entra/workload-id/workload-identity-federation-create-trust).
+
+---
+
+## I
+
+### idtyp (id-type claim)
+
+Optional Entra access-token claim added when configured via an [optional claims policy](https://learn.microsoft.com/entra/identity-platform/optional-claims). Value is `app` for app-only tokens, `user` for delegated tokens. Useful as a *secondary* signal but **not** a substitute for the *roles* + *azp* allow-list — `idtyp` alone does not pin which client app may call you. [Access token claims reference](https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference).
+
+### IssuerValidator (`AadIssuerValidator`)
+
+`Microsoft.IdentityModel.Validators.AadIssuerValidator` — the validator that resolves the per-tenant issuer URL for a multi-tenant app and confirms the token's `iss` matches the cloud-and-tenant the token claims to come from. Required when `TenantId="organizations"` or `"common"`; pair with a `tid` allow-list to restrict *which* tenants you accept. [`AadIssuerValidator` reference](https://learn.microsoft.com/dotnet/api/microsoft.identitymodel.validators.aadissuervalidator), [Microsoft.Identity.Web multi-tenant guidance](https://github.com/AzureAD/microsoft-identity-web/wiki/multi-tenant-web-apis).
+
+---
+
+## M
+
+### Managed Identity (MI) — system-assigned (SAMI), user-assigned (UAMI)
+
+Azure-platform-issued service principal automatically rotated by the platform, accessible from inside Azure compute via the IMDS endpoint. **System-assigned** is bound 1:1 to a single resource lifecycle; **user-assigned** is a standalone resource that can be attached to many compute instances. Default credential for any code running on Azure compute; this sample uses UAMI uniformly. [Managed identities overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview), [System- vs user-assigned](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/managed-identities-faq).
+
+### Microsoft.Identity.Web
+
+ASP.NET Core integration package wrapping *MSAL.NET* + `JwtBearer` middleware. Owns the JWT validation pipeline (`AddMicrosoftIdentityWebApi`), OBO (`GetTokenForUserAsync`), token-cache plumbing, and the `[RequiredScope]` / `[RequiredScopeOrAppPermission]` filters. Default library for ASP.NET Core APIs and web apps in this guide. [Microsoft.Identity.Web docs](https://learn.microsoft.com/entra/identity-platform/microsoft-identity-web), [github.com/AzureAD/microsoft-identity-web](https://github.com/AzureAD/microsoft-identity-web).
+
+### MSAL.NET
+
+`Microsoft.Identity.Client` — the .NET implementation of the Microsoft Authentication Library. Lower-level than *Microsoft.Identity.Web*; use directly in non-ASP.NET hosts (workers, libraries) when you need MSAL features Microsoft.Identity.Web does not surface (claims challenges with custom UX, brokered auth, advanced token-cache wiring). [MSAL overview](https://learn.microsoft.com/entra/identity-platform/msal-overview), [github.com/AzureAD/microsoft-authentication-library-for-dotnet](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet).
+
+### multi-tenant (Entra app)
+
+App registration whose `signInAudience` accepts users / apps from any Entra tenant (`AzureADMultipleOrgs` or `AzureADandPersonalMicrosoftAccount`). The API authority is `organizations` (or `common`); validation requires *IssuerValidator* + a *tid* allow-list. Owned in [`docs/validation.md`](./docs/validation.md) §3. [Convert app to multi-tenant](https://learn.microsoft.com/entra/identity-platform/howto-convert-app-to-be-multi-tenant).
+
+---
+
+## O
+
+### OBO (On-Behalf-Of)
+
+OAuth 2.0 flow ([RFC 8693 OAuth 2.0 Token Exchange](https://www.rfc-editor.org/rfc/rfc8693), Microsoft variant) in which a middle-tier API exchanges the inbound user access token for a new access token to call a downstream API as the same user. Implemented in `Microsoft.Identity.Web` via `IDownstreamApi` / `ITokenAcquisition.GetAccessTokenForUserAsync`. [Microsoft identity platform — OBO flow](https://learn.microsoft.com/entra/identity-platform/v2-oauth2-on-behalf-of-flow).
+
+### OIDC (OpenID Connect)
+
+Identity layer on top of OAuth 2.0 ([RFC 6749](https://www.rfc-editor.org/rfc/rfc6749)) defined in [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html). Standardises the *id_token* (a JWT identifying the user), the `userinfo` endpoint, and discovery (`/.well-known/openid-configuration`). Entra implements the OIDC v1.0 and v2.0 endpoints.
+
+---
+
+## R
+
+### RequiredScope / RequiredScopeOrAppPermission
+
+`Microsoft.Identity.Web` authorization filter attributes that enforce a required *scp* (delegated) or *roles* (app) value on an endpoint. Use *separate* attributes for separate policies — never compose into an OR-claims policy. [Microsoft.Identity.Web — RequiredScope](https://github.com/AzureAD/microsoft-identity-web/wiki/web-apis#protect-aspnet-core-web-apis).
+
+### roles (claim, app role)
+
+JWT claim emitted by Entra carrying the **app roles** assigned to the calling principal (user or app). For app-only tokens, `roles` is the application-permission name; for delegated tokens, `roles` is the user's app-role assignment. Defined per app registration via "App roles" blade. [Add app roles in your application](https://learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps).
+
+---
+
+## S
+
+### scp (claim, scope)
+
+JWT claim emitted by Entra in **delegated** access tokens carrying the space-separated list of OAuth scopes the user consented to. Absent in app-only tokens. Pair with *roles* / *azp* checks to keep delegated and app-only policies separate. [Access token claims reference](https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference).
+
+### SignedAssertionFromManagedIdentity
+
+`Microsoft.Identity.Web.SignedAssertionFromManagedIdentity` — a delegate that uses a Managed Identity to mint a signed JWT, then submits that JWT to Entra as the `client_assertion` for an app registration's `client_credentials` grant. **This is not OIDC Federated Identity Credential**: there is no external OIDC issuer; the assertion is a Managed-Identity-signed JWT used to *replace a client secret* on the app registration via the FIC trust on the same MI. Used by the BFF in this sample. [Microsoft.Identity.Web — Managed identity as a federated credential](https://github.com/AzureAD/microsoft-identity-web/wiki/Using-managed-identity-as-a-federated-identity-credential).
+
+### SPIFFE / SVID
+
+[Secure Production Identity Framework for Everyone](https://spiffe.io/) — CNCF spec for assigning cryptographic workload identities (SPIFFE Verifiable Identity Documents, *SVIDs*) across Kubernetes / mesh / cloud boundaries. Comparable in role to *Managed Identity* and *Federated Identity Credential* but vendor-neutral; mentioned for cross-platform comparison only. [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/).
+
+---
+
+## T
+
+### tenant / tid (claim)
+
+A tenant is an instance of *Entra ID* (one directory). The `tid` claim in a JWT carries the tenant the principal authenticated against. In multi-tenant validation, `tid` is the gate: keep an explicit allow-list of tenant GUIDs; never accept "any tenant" silently. [Access token claims reference](https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference), [Tenant fundamentals](https://learn.microsoft.com/entra/fundamentals/whatis).
+
+---
+
+## V
+
+### v1 vs v2 token (audience format)
+
+Entra emits two token-format generations. **v1.0** tokens use the `aud` claim populated with the resource App ID URI (e.g., `api://orders`); the issuer is `https://sts.windows.net/{tid}/`. **v2.0** tokens use the resource's *App ID* GUID as `aud` (or the App ID URI if configured); the issuer is `https://login.microsoftonline.com/{tid}/v2.0`. Pick v2.0 for new app regs (`accessTokenAcceptedVersion: 2`). The format the API receives must match what its `JwtBearerOptions` expects. [Access tokens — versions](https://learn.microsoft.com/entra/identity-platform/access-tokens), [App manifest reference — `accessTokenAcceptedVersion`](https://learn.microsoft.com/entra/identity-platform/reference-app-manifest).
+
+---
+
+## W
+
+### Workload Identity Federation
+
+Entra-platform feature that lets an external OIDC-compliant identity provider (GitHub Actions, GitLab, Kubernetes service-account issuer, another cloud's OIDC IdP) act as the credential for an Entra app registration or user-assigned managed identity, via [RFC 8693 OAuth 2.0 Token Exchange](https://www.rfc-editor.org/rfc/rfc8693). The on-the-wire credential is a *Federated Identity Credential* (FIC). Default credential pattern for non-Azure compute. [Workload identity federation overview](https://learn.microsoft.com/entra/workload-id/workload-identity-federation).
+
+---
+
+## Sources
+
+- Microsoft identity platform overview — [learn.microsoft.com/entra/identity-platform/v2-overview](https://learn.microsoft.com/entra/identity-platform/v2-overview)
+- Access token claims reference — [learn.microsoft.com/entra/identity-platform/access-token-claims-reference](https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference)
+- ID token claims reference — [learn.microsoft.com/entra/identity-platform/id-token-claims-reference](https://learn.microsoft.com/entra/identity-platform/id-token-claims-reference)
+- Optional claims — [learn.microsoft.com/entra/identity-platform/optional-claims](https://learn.microsoft.com/entra/identity-platform/optional-claims)
+- Permissions and consent overview — [learn.microsoft.com/entra/identity-platform/permissions-consent-overview](https://learn.microsoft.com/entra/identity-platform/permissions-consent-overview)
+- App roles — [learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps](https://learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps)
+- On-Behalf-Of flow — [learn.microsoft.com/entra/identity-platform/v2-oauth2-on-behalf-of-flow](https://learn.microsoft.com/entra/identity-platform/v2-oauth2-on-behalf-of-flow)
+- Continuous access evaluation — [learn.microsoft.com/entra/identity/conditional-access/concept-continuous-access-evaluation](https://learn.microsoft.com/entra/identity/conditional-access/concept-continuous-access-evaluation)
+- Conditional Access — auth context — [learn.microsoft.com/entra/identity/conditional-access/concept-conditional-access-cloud-apps](https://learn.microsoft.com/entra/identity/conditional-access/concept-conditional-access-cloud-apps)
+- Managed identities for Azure resources — [learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview)
+- Workload identity federation — [learn.microsoft.com/entra/workload-id/workload-identity-federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+- Configure a federated identity credential — [learn.microsoft.com/entra/workload-id/workload-identity-federation-create-trust](https://learn.microsoft.com/entra/workload-id/workload-identity-federation-create-trust)
+- Microsoft.Identity.Web — [learn.microsoft.com/entra/identity-platform/microsoft-identity-web](https://learn.microsoft.com/entra/identity-platform/microsoft-identity-web), [github.com/AzureAD/microsoft-identity-web](https://github.com/AzureAD/microsoft-identity-web)
+- MSAL.NET — [learn.microsoft.com/entra/identity-platform/msal-overview](https://learn.microsoft.com/entra/identity-platform/msal-overview), [github.com/AzureAD/microsoft-authentication-library-for-dotnet](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet)
+- Azure.Identity — [learn.microsoft.com/dotnet/api/overview/azure/identity-readme](https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme), [github.com/Azure/azure-sdk-for-net](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity)
+- DefaultAzureCredential — [learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential)
+- Convert app to multi-tenant — [learn.microsoft.com/entra/identity-platform/howto-convert-app-to-be-multi-tenant](https://learn.microsoft.com/entra/identity-platform/howto-convert-app-to-be-multi-tenant)
+- Access tokens — versions — [learn.microsoft.com/entra/identity-platform/access-tokens](https://learn.microsoft.com/entra/identity-platform/access-tokens)
+- App manifest reference — [learn.microsoft.com/entra/identity-platform/reference-app-manifest](https://learn.microsoft.com/entra/identity-platform/reference-app-manifest)
+- `AadIssuerValidator` — [learn.microsoft.com/dotnet/api/microsoft.identitymodel.validators.aadissuervalidator](https://learn.microsoft.com/dotnet/api/microsoft.identitymodel.validators.aadissuervalidator)
+- Microsoft.Identity.Web — Managed identity as a federated credential — [github.com/AzureAD/microsoft-identity-web/wiki/Using-managed-identity-as-a-federated-identity-credential](https://github.com/AzureAD/microsoft-identity-web/wiki/Using-managed-identity-as-a-federated-identity-credential)
+- Backends-for-Frontends pattern — [learn.microsoft.com/azure/architecture/patterns/backends-for-frontends](https://learn.microsoft.com/azure/architecture/patterns/backends-for-frontends)
+- SPIFFE — [spiffe.io/docs/latest/spiffe-about/overview/](https://spiffe.io/docs/latest/spiffe-about/overview/)
+- RFC 6749 — The OAuth 2.0 Authorization Framework — [rfc-editor.org/rfc/rfc6749](https://www.rfc-editor.org/rfc/rfc6749)
+- RFC 7519 — JSON Web Token (JWT) — [rfc-editor.org/rfc/rfc7519](https://www.rfc-editor.org/rfc/rfc7519)
+- RFC 8693 — OAuth 2.0 Token Exchange — [rfc-editor.org/rfc/rfc8693](https://www.rfc-editor.org/rfc/rfc8693)
+- OpenID Connect Core 1.0 — [openid.net/specs/openid-connect-core-1_0.html](https://openid.net/specs/openid-connect-core-1_0.html)


### PR DESCRIPTION
Adds the four cross-cutting synthesis artifacts that mirror the format used by
the companion mghabin/dotnet-engineering-guide and mghabin/infra-engineering-guide
repos:

- SCOPE.md: who this guide is for, who it isn't, non-goals, reading paths,
  out-of-scope redirects (consumer MSA, IGA, hybrid identity, mobile auth).
- coverage-map.md: ownership matrix per concept (acquisition, validation,
  credential-patterns, sample-setup, etc.) — siblings link, never re-decide.
- glossary.md: alphabetical, every normatively-used Entra term with primary
  source link (azp/appid, scp, roles, FIC, MI, IssuerValidator, OBO, CAE,
  ACRS, SignedAssertionFromManagedIdentity vs OIDC-FIC, v1 vs v2 token).
- docs/decision-trees.md: 5 Mermaid trees (caller identity, host platform,
  tenancy, policy shape, credential type) cross-linked to the dotnet-guide
  ch02 §10 and infra-guide ch06 §3 owners.

Updates README.md with a 'Read this first' section that points at the four
artifacts as the reading-path entry, and adds a one-liner under the inline
decision tree pointing readers at the full set in docs/decision-trees.md.

Doctrine constraints applied: synthesis pages point at owners, never
re-decide. Every normative claim cites a primary source (RFC 6749/7519/8693,
OIDC Core, Microsoft Learn Entra, Microsoft.Identity.Web/MSAL.NET/Azure.Identity
GitHub repos). Mirrors the dotnet-guide ch02 §10 doctrine: separate delegated
(scp) vs app-only (roles + azp) policies, never an OR-claims policy;
multi-tenant uses IssuerValidator + tid allow-list.

Pre-flight: markdownlint-cli2 passes on all new files; cross-file fragment
links validated with the same anchor-validation script as the dotnet-guide
campaign (also fixes one pre-existing latent broken anchor in
docs/acquisition.md → docs/validation.md#5-mi-tokens).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
