### PR TITLE
feat(auth): named policies (OrdersDelegated/OrdersApp) + defensive JWT defaults + CAE surfacing

### DIFF
--- a/src/Ftgo.Auth.Client/ClaimsChallengeRequiredException.cs
+++ b/src/Ftgo.Auth.Client/ClaimsChallengeRequiredException.cs
@@ -1,0 +1,40 @@
+namespace Ftgo.Auth;
+
+/// <summary>
+/// Thrown when a downstream API responds with a Continuous Access Evaluation (CAE) / claims-challenge
+/// signal: <c>WWW-Authenticate: Bearer error="insufficient_claims", claims="&lt;b64url&gt;"</c>.
+/// </summary>
+/// <remarks>
+/// Callers should re-acquire a token using <see cref="Claims"/> as the <c>claims</c> parameter on the
+/// token request (e.g. MSAL <c>WithClaims</c>) and retry. The raw <c>WWW-Authenticate</c> header is
+/// preserved on <see cref="WwwAuthenticate"/> for callers that need to parse additional parameters via
+/// <c>Microsoft.Identity.Web.Resource.WwwAuthenticateParameters</c>.
+/// </remarks>
+public sealed class ClaimsChallengeRequiredException : Exception
+{
+    public int StatusCode { get; }
+    public string Claims { get; }
+    public string WwwAuthenticate { get; }
+
+    public ClaimsChallengeRequiredException(int statusCode, string claims, string wwwAuthenticate)
+        : base($"Downstream returned {statusCode} with claims-challenge; caller must re-acquire token with the supplied claims.")
+    {
+        StatusCode = statusCode;
+        Claims = claims;
+        WwwAuthenticate = wwwAuthenticate;
+    }
+
+    public ClaimsChallengeRequiredException() : this(0, string.Empty, string.Empty) { }
+
+    public ClaimsChallengeRequiredException(string message) : base(message)
+    {
+        Claims = string.Empty;
+        WwwAuthenticate = string.Empty;
+    }
+
+    public ClaimsChallengeRequiredException(string message, Exception innerException) : base(message, innerException)
+    {
+        Claims = string.Empty;
+        WwwAuthenticate = string.Empty;
+    }
+}

--- a/src/Ftgo.Auth.Client/DownstreamApiClient.cs
+++ b/src/Ftgo.Auth.Client/DownstreamApiClient.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using Microsoft.Extensions.Logging;
 
@@ -30,7 +31,101 @@ public sealed partial class DownstreamApiClient(
         var body = await response.Content.ReadAsStringAsync(cancellationToken);
 
         LogProbe(logger, (int)response.StatusCode, path);
+
+        // CAE / step-up: surface the claims challenge so the caller can re-acquire with `WithClaims`
+        // (or otherwise pass the parameter on its next token request) and retry. Never swallow it —
+        // the downstream is telling us the existing token is no longer sufficient.
+        // Callers can additionally parse the raw header via
+        // Microsoft.Identity.Web.Resource.WwwAuthenticateParameters.CreateFromAuthenticationHeaders().
+        if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        {
+            var (claims, raw) = TryExtractClaimsChallenge(response.Headers.WwwAuthenticate);
+            if (claims is not null)
+            {
+                LogClaimsChallenge(logger, (int)response.StatusCode, path);
+                throw new ClaimsChallengeRequiredException((int)response.StatusCode, claims, raw!);
+            }
+        }
+
         return ((int)response.StatusCode, body);
+    }
+
+    /// <summary>
+    /// Parse <c>WWW-Authenticate</c> challenges for a Bearer challenge of the form
+    /// <c>Bearer error="insufficient_claims", claims="&lt;b64url&gt;"</c>. Returns <c>(null,null)</c>
+    /// when no claims challenge is present.
+    /// </summary>
+    internal static (string? Claims, string? Raw) TryExtractClaimsChallenge(
+        HttpHeaderValueCollection<AuthenticationHeaderValue> wwwAuthenticate)
+    {
+        foreach (var header in wwwAuthenticate)
+        {
+            if (!string.Equals(header.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            if (string.IsNullOrEmpty(header.Parameter))
+            {
+                continue;
+            }
+
+            var raw = header.ToString();
+            var claims = ExtractParameter(header.Parameter, "claims");
+            if (claims is not null)
+            {
+                return (claims, raw);
+            }
+        }
+
+        return (null, null);
+    }
+
+    private static string? ExtractParameter(string parameter, string name)
+    {
+        // RFC 7235 challenge auth-params are comma-separated `name=value` pairs where value may be quoted.
+        var parts = SplitTopLevel(parameter, ',');
+        foreach (var part in parts)
+        {
+            var eq = part.IndexOf('=', StringComparison.Ordinal);
+            if (eq < 0)
+            {
+                continue;
+            }
+            var key = part[..eq].Trim();
+            if (!string.Equals(key, name, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            var value = part[(eq + 1)..].Trim();
+            if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+            {
+                value = value[1..^1];
+            }
+            return value;
+        }
+        return null;
+    }
+
+    private static List<string> SplitTopLevel(string input, char separator)
+    {
+        var result = new List<string>();
+        var inQuotes = false;
+        var start = 0;
+        for (var i = 0; i < input.Length; i++)
+        {
+            var ch = input[i];
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (ch == separator && !inQuotes)
+            {
+                result.Add(input[start..i]);
+                start = i + 1;
+            }
+        }
+        result.Add(input[start..]);
+        return result;
     }
 
     [LoggerMessage(
@@ -38,4 +133,10 @@ public sealed partial class DownstreamApiClient(
         Level = LogLevel.Information,
         Message = "Downstream probe complete. Status={Status} Path={Path}")]
     private static partial void LogProbe(ILogger logger, int status, string path);
+
+    [LoggerMessage(
+        EventId = 2001,
+        Level = LogLevel.Warning,
+        Message = "Downstream returned claims-challenge. Status={Status} Path={Path}")]
+    private static partial void LogClaimsChallenge(ILogger logger, int status, string path);
 }

--- a/src/Ftgo.Auth/EntraAuthServiceCollectionExtensions.cs
+++ b/src/Ftgo.Auth/EntraAuthServiceCollectionExtensions.cs
@@ -53,6 +53,8 @@ public static class EntraAuthServiceCollectionExtensions
             });
         });
         services.AddSingleton<IAuthorizationHandler, RequireClientAppHandler>();
+        services.AddSingleton<IAuthorizationHandler, RequireDelegatedScopeHandler>();
+        services.AddSingleton<IAuthorizationHandler, RequireAppRoleHandler>();
 
         return services;
     }
@@ -72,6 +74,17 @@ internal sealed class EntraAuthJwtPostConfigure(
 
         var opts = options.Value;
         var clientId = configuration["AzureAd:ClientId"];
+
+        // Defense in depth — be explicit about every validator. Defaults shift between SDK
+        // versions; doctrine (eng-guide ch02 §10.1) requires we pin them at the call site so a
+        // future SDK upgrade can't silently flip a switch off.
+        bearerOptions.MapInboundClaims = false; // preserve scp/roles/azp verbatim.
+        bearerOptions.TokenValidationParameters.ValidateIssuerSigningKey = true;
+        bearerOptions.TokenValidationParameters.ValidateLifetime = true;
+        bearerOptions.TokenValidationParameters.ValidateAudience = true;
+        bearerOptions.TokenValidationParameters.ValidateIssuer = true;
+        bearerOptions.TokenValidationParameters.RequireSignedTokens = true;
+        bearerOptions.TokenValidationParameters.RequireExpirationTime = true;
 
         var validAudiences = new List<string>();
         if (!string.IsNullOrWhiteSpace(clientId)) validAudiences.Add(clientId);

--- a/src/Ftgo.Auth/MixedClaimsPolicies.cs
+++ b/src/Ftgo.Auth/MixedClaimsPolicies.cs
@@ -1,0 +1,193 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Ftgo.Auth;
+
+/// <summary>
+/// Authorization requirement enforcing the doctrine that a delegated (user) endpoint must see a
+/// token with at least one of the required <c>scp</c> values <i>and</i> no <c>roles</c> claim.
+/// </summary>
+/// <remarks>
+/// Backs the named "delegated" half of the doctrine that every API split between user and app
+/// callers expose two mutually-exclusive named policies — never an OR-claims policy. See the
+/// dotnet-engineering-guide ch02 §10 ("Never accept tokens that have both <c>scp</c> and <c>roles</c>
+/// claims; that means a misconfigured app reg minted a token with both kinds of permissions.") and
+/// <see href="https://github.com/mghabin/entra-auth-patterns-dotnet/blob/main/docs/decision-trees.md">decision-trees.md</see>
+/// Tree 4.
+/// </remarks>
+public sealed class RequireDelegatedScopeRequirement : IAuthorizationRequirement
+{
+    public IReadOnlyCollection<string> RequiredScopes { get; }
+
+    public RequireDelegatedScopeRequirement(params string[] requiredScopes)
+    {
+        ArgumentNullException.ThrowIfNull(requiredScopes);
+        if (requiredScopes.Length == 0)
+        {
+            throw new ArgumentException("At least one scope must be supplied.", nameof(requiredScopes));
+        }
+        RequiredScopes = requiredScopes;
+    }
+}
+
+internal sealed class RequireDelegatedScopeHandler
+    : AuthorizationHandler<RequireDelegatedScopeRequirement>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        RequireDelegatedScopeRequirement requirement)
+    {
+        if (context.User.Identity?.IsAuthenticated != true)
+        {
+            return Task.CompletedTask;
+        }
+
+        // Doctrine: a delegated (user) token never carries `roles`. Reject mixed tokens —
+        // they indicate a misconfigured app registration (both scope and app-role consents).
+        if (context.User.HasClaim(c => string.Equals(c.Type, "roles", StringComparison.Ordinal)))
+        {
+            context.Fail(new AuthorizationFailureReason(this,
+                "Delegated endpoint received a token that also carries `roles` (mixed scp+roles)."));
+            return Task.CompletedTask;
+        }
+
+        var scpClaim = context.User.FindFirst("scp")?.Value
+                       ?? context.User.FindFirst("http://schemas.microsoft.com/identity/claims/scope")?.Value;
+        if (string.IsNullOrEmpty(scpClaim))
+        {
+            context.Fail(new AuthorizationFailureReason(this, "Delegated endpoint requires an `scp` claim."));
+            return Task.CompletedTask;
+        }
+
+        var present = scpClaim.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (!requirement.RequiredScopes.Any(req =>
+                present.Contains(req, StringComparer.Ordinal)))
+        {
+            context.Fail(new AuthorizationFailureReason(this,
+                string.Create(CultureInfo.InvariantCulture,
+                    $"Delegated endpoint requires one of scp [{string.Join(", ", requirement.RequiredScopes)}].")));
+            return Task.CompletedTask;
+        }
+
+        context.Succeed(requirement);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Authorization requirement enforcing the doctrine that an app-only endpoint must see a token
+/// with the required app-role and no <c>scp</c> claim. Pair with <see cref="RequireClientAppRequirement"/>
+/// to also enforce the <c>azp</c> allow-list.
+/// </summary>
+/// <remarks>
+/// Mirrors <see cref="RequireDelegatedScopeRequirement"/> as the "app" half of the doctrine — see
+/// the dotnet-engineering-guide ch02 §10 and
+/// <see href="https://github.com/mghabin/entra-auth-patterns-dotnet/blob/main/docs/decision-trees.md">decision-trees.md</see>
+/// Tree 4.
+/// </remarks>
+public sealed class RequireAppRoleRequirement : IAuthorizationRequirement
+{
+    public string RequiredRole { get; }
+
+    public RequireAppRoleRequirement(string requiredRole)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(requiredRole);
+        RequiredRole = requiredRole;
+    }
+}
+
+internal sealed class RequireAppRoleHandler
+    : AuthorizationHandler<RequireAppRoleRequirement>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        RequireAppRoleRequirement requirement)
+    {
+        if (context.User.Identity?.IsAuthenticated != true)
+        {
+            return Task.CompletedTask;
+        }
+
+        // Doctrine: an app-only token never carries `scp`. Reject mixed tokens.
+        if (context.User.HasClaim(c =>
+                string.Equals(c.Type, "scp", StringComparison.Ordinal) ||
+                string.Equals(c.Type, "http://schemas.microsoft.com/identity/claims/scope", StringComparison.Ordinal)))
+        {
+            context.Fail(new AuthorizationFailureReason(this,
+                "App-only endpoint received a token that also carries `scp` (mixed scp+roles)."));
+            return Task.CompletedTask;
+        }
+
+        var hasRole = context.User.FindAll("roles")
+            .Any(c => string.Equals(c.Value, requirement.RequiredRole, StringComparison.Ordinal));
+        if (!hasRole)
+        {
+            context.Fail(new AuthorizationFailureReason(this,
+                string.Create(CultureInfo.InvariantCulture,
+                    $"App-only endpoint requires app-role '{requirement.RequiredRole}'.")));
+            return Task.CompletedTask;
+        }
+
+        context.Succeed(requirement);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>Helpers that register the two-named-policy doctrine on an <see cref="AuthorizationOptions"/>.</summary>
+public static class MixedClaimsAuthorizationExtensions
+{
+    /// <summary>
+    /// Registers a named delegated (user-token) policy. The policy requires an authenticated user, asserts the
+    /// token carries at least one of the required <paramref name="requiredScopes"/> values in <c>scp</c>, and
+    /// rejects any token that <i>also</i> carries a <c>roles</c> claim.
+    /// </summary>
+    /// <remarks>
+    /// Pair with <see cref="AddAppPolicy"/> on the same API to expose the second named policy required by the
+    /// doctrine. See ch02 §10 and
+    /// <see href="https://github.com/mghabin/entra-auth-patterns-dotnet/blob/main/docs/decision-trees.md">decision-trees.md</see>
+    /// Tree 4.
+    /// </remarks>
+    public static AuthorizationOptions AddDelegatedPolicy(
+        this AuthorizationOptions options,
+        string policyName,
+        params string[] requiredScopes)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(policyName);
+
+        options.AddPolicy(policyName, p =>
+        {
+            p.RequireAuthenticatedUser();
+            p.Requirements.Add(new RequireDelegatedScopeRequirement(requiredScopes));
+        });
+        return options;
+    }
+
+    /// <summary>
+    /// Registers a named app-only policy. The policy requires an authenticated user, asserts the token carries
+    /// the <paramref name="requiredRole"/> in <c>roles</c>, rejects any token that <i>also</i> carries
+    /// <c>scp</c>, and enforces the <c>azp</c>/<c>appid</c> allow-list via <see cref="RequireClientAppRequirement"/>.
+    /// </summary>
+    /// <remarks>
+    /// Pair with <see cref="AddDelegatedPolicy"/> on the same API to expose the first named policy required by the
+    /// doctrine. See ch02 §10 and
+    /// <see href="https://github.com/mghabin/entra-auth-patterns-dotnet/blob/main/docs/decision-trees.md">decision-trees.md</see>
+    /// Tree 4.
+    /// </remarks>
+    public static AuthorizationOptions AddAppPolicy(
+        this AuthorizationOptions options,
+        string policyName,
+        string requiredRole)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(policyName);
+
+        options.AddPolicy(policyName, p =>
+        {
+            p.RequireAuthenticatedUser();
+            p.Requirements.Add(new RequireAppRoleRequirement(requiredRole));
+            p.Requirements.Add(new RequireClientAppRequirement());
+        });
+        return options;
+    }
+}

--- a/src/Ftgo.Orders.Api/Controllers/OrdersController.cs
+++ b/src/Ftgo.Orders.Api/Controllers/OrdersController.cs
@@ -1,19 +1,15 @@
-using Ftgo.Auth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Identity.Web;
-using Microsoft.Identity.Web.Resource;
 
 namespace Ftgo.Orders.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize]
 public sealed class OrdersController : ControllerBase
 {
-    /// <summary>User-token endpoint.</summary>
+    /// <summary>User-token endpoint. Bound to the <see cref="OrdersAuthorizationPolicies.Delegated"/> named policy.</summary>
     [HttpGet("whoami")]
-    [RequiredScope("orders.read")]
+    [Authorize(Policy = OrdersAuthorizationPolicies.Delegated)]
     public IActionResult WhoAmI() => Ok(new
     {
         service = "Ftgo.Orders.Api",
@@ -24,10 +20,9 @@ public sealed class OrdersController : ControllerBase
         name = User.FindFirst("name")?.Value
     });
 
-    /// <summary>App-only endpoint: requires the <c>Orders.Process</c> role and an allow-listed caller app.</summary>
+    /// <summary>App-only endpoint. Bound to the <see cref="OrdersAuthorizationPolicies.App"/> named policy.</summary>
     [HttpGet("system")]
-    [Authorize(Roles = "Orders.Process")]
-    [RequireClientApp]
+    [Authorize(Policy = OrdersAuthorizationPolicies.App)]
     public IActionResult System() => Ok(new
     {
         service = "Ftgo.Orders.Api",

--- a/src/Ftgo.Orders.Api/OrdersAuthorizationPolicies.cs
+++ b/src/Ftgo.Orders.Api/OrdersAuthorizationPolicies.cs
@@ -1,0 +1,21 @@
+namespace Ftgo.Orders.Api;
+
+/// <summary>
+/// Named authorization policy identifiers for Orders.Api.
+/// </summary>
+/// <remarks>
+/// Doctrine: APIs that accept both delegated <i>and</i> app callers expose two separate named
+/// policies — never an OR-claims policy and never a single policy that ORs <c>scp</c> with
+/// <c>roles</c>. Each policy is mutually exclusive with the other (a token with both <c>scp</c>
+/// and <c>roles</c> is rejected by both). See dotnet-engineering-guide ch02 §10 and
+/// <see href="https://github.com/mghabin/entra-auth-patterns-dotnet/blob/main/docs/decision-trees.md">decision-trees.md</see>
+/// Tree 4.
+/// </remarks>
+public static class OrdersAuthorizationPolicies
+{
+    /// <summary>Delegated (user-token, OBO) callers — requires <c>scp=orders.read</c> and rejects tokens with <c>roles</c>.</summary>
+    public const string Delegated = "OrdersDelegated";
+
+    /// <summary>App-only (S2S) callers — requires <c>roles=Orders.Process</c>, an allow-listed <c>azp</c>, and rejects tokens with <c>scp</c>.</summary>
+    public const string App = "OrdersApp";
+}

--- a/src/Ftgo.Orders.Api/Program.cs
+++ b/src/Ftgo.Orders.Api/Program.cs
@@ -1,4 +1,5 @@
 using Ftgo.Auth;
+using Ftgo.Orders.Api;
 using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,6 +9,15 @@ builder.Services.AddEntraAuthProblemDetails();
 builder.Services.AddOpenApi();
 builder.Services.AddControllers();
 builder.Services.AddHealthChecks();
+
+// Doctrine: split delegated vs app into two named, mutually-exclusive policies.
+// Never accept tokens that carry both `scp` and `roles` — that means a misconfigured app
+// registration minted a mixed token. See eng-guide ch02 §10 / decision-trees.md Tree 4.
+builder.Services.AddAuthorization(o =>
+{
+    o.AddDelegatedPolicy(OrdersAuthorizationPolicies.Delegated, "orders.read");
+    o.AddAppPolicy(OrdersAuthorizationPolicies.App, "Orders.Process");
+});
 
 var app = builder.Build();
 app.UseEntraAuthProblemDetails();

--- a/tests/Ftgo.Auth.Tests/DownstreamApiClientClaimsChallengeTests.cs
+++ b/tests/Ftgo.Auth.Tests/DownstreamApiClientClaimsChallengeTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Ftgo.Auth;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Ftgo.Auth.Tests;
+
+public sealed class DownstreamApiClientClaimsChallengeTests
+{
+    private sealed class StaticTokenProvider : IAppTokenProvider
+    {
+        public ValueTask<string> GetAccessTokenAsync(string scope, CancellationToken cancellationToken) =>
+            ValueTask.FromResult("test-token");
+    }
+
+    private sealed class StubHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(response);
+    }
+
+    private static DownstreamApiClient BuildClient(HttpResponseMessage response)
+    {
+        var http = new HttpClient(new StubHandler(response)) { BaseAddress = new Uri("https://example.test") };
+        return new DownstreamApiClient(http, new StaticTokenProvider(), NullLogger<DownstreamApiClient>.Instance);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_Throws_WhenDownstream401_HasInsufficientClaimsChallenge()
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        {
+            Content = new StringContent("denied"),
+        };
+        resp.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue(
+            "Bearer",
+            "error=\"insufficient_claims\", claims=\"eyJhY2Nlc3NfdG9rZW4iOnt9fQ==\""));
+
+        var client = BuildClient(resp);
+
+        var ex = await Should.ThrowAsync<ClaimsChallengeRequiredException>(async () =>
+            await client.ProbeAsync("/probe", "api://x/.default", TestContext.Current.CancellationToken));
+        ex.StatusCode.ShouldBe(401);
+        ex.Claims.ShouldBe("eyJhY2Nlc3NfdG9rZW4iOnt9fQ==");
+        ex.WwwAuthenticate.ShouldContain("insufficient_claims");
+    }
+
+    [Fact]
+    public async Task ProbeAsync_Throws_WhenDownstream403_HasClaimsChallenge()
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.Forbidden);
+        resp.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue(
+            "Bearer",
+            "error=\"insufficient_claims\", claims=\"abc123\", error_description=\"step-up needed\""));
+
+        var client = BuildClient(resp);
+
+        var ex = await Should.ThrowAsync<ClaimsChallengeRequiredException>(async () =>
+            await client.ProbeAsync("/probe", "scope", TestContext.Current.CancellationToken));
+        ex.Claims.ShouldBe("abc123");
+    }
+
+    [Fact]
+    public async Task ProbeAsync_DoesNotThrow_When401_HasNoClaimsParameter()
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        {
+            Content = new StringContent("nope"),
+        };
+        resp.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue("Bearer", "error=\"invalid_token\""));
+
+        var client = BuildClient(resp);
+        var (status, body) = await client.ProbeAsync("/probe", "scope", TestContext.Current.CancellationToken);
+
+        status.ShouldBe(401);
+        body.ShouldBe("nope");
+    }
+
+    [Fact]
+    public async Task ProbeAsync_ReturnsBody_OnSuccess()
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+        var client = BuildClient(resp);
+
+        var (status, body) = await client.ProbeAsync("/probe", "scope", TestContext.Current.CancellationToken);
+
+        status.ShouldBe(200);
+        body.ShouldBe("ok");
+    }
+}

--- a/tests/Ftgo.Auth.Tests/EntraAuthJwtPostConfigureTests.cs
+++ b/tests/Ftgo.Auth.Tests/EntraAuthJwtPostConfigureTests.cs
@@ -107,6 +107,25 @@ public sealed class EntraAuthJwtPostConfigureTests
         Should.Throw<InvalidOperationException>(
             () => sut.PostConfigure(JwtBearerDefaults.AuthenticationScheme, jwtOptions));
     }
+
+    [Fact]
+    public void PostConfigure_PinsExplicitDefensiveValidationDefaults()
+    {
+        var sut = CreateSut(new EntraAuthOptions(), BuildConfig(Guid.NewGuid().ToString()));
+        var jwtOptions = new JwtBearerOptions();
+
+        sut.PostConfigure(JwtBearerDefaults.AuthenticationScheme, jwtOptions);
+
+        // Doctrine (eng-guide ch02 §10.1): be explicit about every validator — defaults
+        // shift between SDK versions.
+        jwtOptions.MapInboundClaims.ShouldBeFalse();
+        jwtOptions.TokenValidationParameters.ValidateIssuerSigningKey.ShouldBeTrue();
+        jwtOptions.TokenValidationParameters.ValidateLifetime.ShouldBeTrue();
+        jwtOptions.TokenValidationParameters.ValidateAudience.ShouldBeTrue();
+        jwtOptions.TokenValidationParameters.ValidateIssuer.ShouldBeTrue();
+        jwtOptions.TokenValidationParameters.RequireSignedTokens.ShouldBeTrue();
+        jwtOptions.TokenValidationParameters.RequireExpirationTime.ShouldBeTrue();
+    }
 }
 
 public sealed class RequireClientAppAttributeTests

--- a/tests/Ftgo.Auth.Tests/MixedClaimsPolicyHandlerTests.cs
+++ b/tests/Ftgo.Auth.Tests/MixedClaimsPolicyHandlerTests.cs
@@ -1,0 +1,159 @@
+using System.Security.Claims;
+using Ftgo.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Ftgo.Auth.Tests;
+
+public sealed class MixedClaimsPolicyHandlerTests
+{
+    private static AuthorizationHandlerContext MakeContext(ClaimsPrincipal user, params IAuthorizationRequirement[] reqs) =>
+        new(reqs, user, resource: null);
+
+    private static ClaimsPrincipal Principal(params (string type, string value)[] claims) =>
+        new(new ClaimsIdentity(claims.Select(c => new Claim(c.type, c.value)), authenticationType: "jwt"));
+
+    private static IOptionsMonitor<EntraAuthOptions> Monitor(EntraAuthOptions opts)
+    {
+        var monitor = Substitute.For<IOptionsMonitor<EntraAuthOptions>>();
+        monitor.CurrentValue.Returns(opts);
+        return monitor;
+    }
+
+    // --- RequireDelegatedScopeHandler ---
+
+    [Fact]
+    public async Task DelegatedScope_Succeeds_WhenScpContainsRequiredScope_AndNoRoles()
+    {
+        var handler = new RequireDelegatedScopeHandler();
+        var req = new RequireDelegatedScopeRequirement("orders.read");
+        var ctx = MakeContext(Principal(("scp", "orders.read")), req);
+
+        await handler.HandleAsync(ctx);
+
+        ctx.HasSucceeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task OrdersDelegated_RejectsTokenWithRoles()
+    {
+        var handler = new RequireDelegatedScopeHandler();
+        var req = new RequireDelegatedScopeRequirement("orders.read");
+        var ctx = MakeContext(Principal(("scp", "orders.read"), ("roles", "Orders.Process")), req);
+
+        await handler.HandleAsync(ctx);
+
+        ctx.HasSucceeded.ShouldBeFalse();
+        ctx.HasFailed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DelegatedScope_Rejects_WhenScpMissing()
+    {
+        var handler = new RequireDelegatedScopeHandler();
+        var ctx = MakeContext(Principal(("oid", Guid.NewGuid().ToString())), new RequireDelegatedScopeRequirement("orders.read"));
+
+        await handler.HandleAsync(ctx);
+
+        ctx.HasFailed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DelegatedScope_Rejects_WhenScpDoesNotContainRequired()
+    {
+        var handler = new RequireDelegatedScopeHandler();
+        var ctx = MakeContext(Principal(("scp", "user.read other.scope")), new RequireDelegatedScopeRequirement("orders.read"));
+
+        await handler.HandleAsync(ctx);
+
+        ctx.HasFailed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DelegatedScope_Succeeds_WhenScpContainsAnyRequiredScope()
+    {
+        var handler = new RequireDelegatedScopeHandler();
+        var ctx = MakeContext(
+            Principal(("scp", "orders.read other.scope")),
+            new RequireDelegatedScopeRequirement("orders.write", "orders.read"));
+
+        await handler.HandleAsync(ctx);
+
+        ctx.HasSucceeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DelegatedScope_Rejects_Unauthenticated()
+    {
+        var handler = new RequireDelegatedScopeHandler();
+        var ctx = MakeContext(new ClaimsPrincipal(new ClaimsIdentity()), new RequireDelegatedScopeRequirement("orders.read"));
+
+        await handler.HandleAsync(ctx);
+
+        ctx.HasSucceeded.ShouldBeFalse();
+    }
+
+    // --- RequireAppRoleHandler ---
+
+    [Fact]
+    public async Task AppRole_Succeeds_WhenRolesContainsRequired_AndNoScp()
+    {
+        var handler = new RequireAppRoleHandler();
+        var ctx = MakeContext(Principal(("roles", "Orders.Process")), new RequireAppRoleRequirement("Orders.Process"));
+
+        await handler.HandleAsync(ctx);
+
+        ctx.HasSucceeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task OrdersApp_RejectsTokenWithScp()
+    {
+        var handler = new RequireAppRoleHandler();
+        var ctx = MakeContext(
+            Principal(("roles", "Orders.Process"), ("scp", "orders.read")),
+            new RequireAppRoleRequirement("Orders.Process"));
+
+        await handler.HandleAsync(ctx);
+
+        ctx.HasSucceeded.ShouldBeFalse();
+        ctx.HasFailed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AppRole_Rejects_WhenRolesMissing()
+    {
+        var handler = new RequireAppRoleHandler();
+        var ctx = MakeContext(Principal(("azp", "x")), new RequireAppRoleRequirement("Orders.Process"));
+
+        await handler.HandleAsync(ctx);
+
+        ctx.HasFailed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AppRole_Rejects_WhenRolesValueDoesNotMatch()
+    {
+        var handler = new RequireAppRoleHandler();
+        var ctx = MakeContext(Principal(("roles", "Other.Role")), new RequireAppRoleRequirement("Orders.Process"));
+
+        await handler.HandleAsync(ctx);
+
+        ctx.HasFailed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RequireDelegatedScopeRequirement_Throws_WhenNoScopes()
+    {
+        Should.Throw<ArgumentException>(() => new RequireDelegatedScopeRequirement());
+    }
+
+    [Fact]
+    public void RequireAppRoleRequirement_Throws_WhenRoleBlank()
+    {
+        Should.Throw<ArgumentException>(() => new RequireAppRoleRequirement("  "));
+    }
+}

--- a/tests/Ftgo.Auth.Tests/OrdersNamedPoliciesEndToEndTests.cs
+++ b/tests/Ftgo.Auth.Tests/OrdersNamedPoliciesEndToEndTests.cs
@@ -1,0 +1,157 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using Ftgo.Auth;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Ftgo.Auth.Tests;
+
+/// <summary>
+/// End-to-end coverage of the two-named-policy doctrine wired via the public
+/// <see cref="MixedClaimsAuthorizationExtensions.AddDelegatedPolicy"/> and
+/// <see cref="MixedClaimsAuthorizationExtensions.AddAppPolicy"/> helpers — exactly the way
+/// Ftgo.Orders.Api wires "OrdersDelegated"/"OrdersApp".
+/// </summary>
+public sealed class OrdersNamedPoliciesEndToEndTests : IAsyncLifetime
+{
+#pragma warning disable IDE1006 // const is conceptually a constant, not a private field
+    private const string AllowedAppId = "11111111-1111-1111-1111-111111111111";
+    private const string DelegatedPolicy = "OrdersDelegated";
+    private const string AppPolicy = "OrdersApp";
+#pragma warning restore IDE1006
+
+    private IHost _host = null!;
+    private HttpClient _client = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await new HostBuilder()
+            .ConfigureWebHost(web => web
+                .UseTestServer()
+                .ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddSingleton<IOptionsMonitor<EntraAuthOptions>>(_ =>
+                        new StaticOptionsMonitor<EntraAuthOptions>(new EntraAuthOptions
+                        {
+                            AllowedClientApps = [AllowedAppId],
+                        }));
+
+                    services.AddAuthentication(TestAuthHandler.SchemeName)
+                        .AddScheme<TestAuthSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });
+
+                    services.AddAuthorization(o =>
+                    {
+                        o.AddDelegatedPolicy(DelegatedPolicy, "orders.read");
+                        o.AddAppPolicy(AppPolicy, "Orders.Process");
+
+                        // Pin the test scheme onto the doctrine policies so MapGet([Authorize(Policy=...)])
+                        // resolves against the Test handler (mirrors the JWT scheme in production).
+                        foreach (var name in new[] { DelegatedPolicy, AppPolicy })
+                        {
+                            var existing = o.GetPolicy(name)!;
+                            o.AddPolicy(name, new AuthorizationPolicyBuilder(TestAuthHandler.SchemeName)
+                                .Combine(existing)
+                                .Build());
+                        }
+                    });
+                    services.AddSingleton<IAuthorizationHandler, RequireClientAppHandler>();
+                    services.AddSingleton<IAuthorizationHandler, RequireDelegatedScopeHandler>();
+                    services.AddSingleton<IAuthorizationHandler, RequireAppRoleHandler>();
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseAuthentication();
+                    app.UseAuthorization();
+                    app.UseEndpoints(e =>
+                    {
+                        e.MapGet("/whoami", () => Results.Ok("user")).RequireAuthorization(DelegatedPolicy);
+                        e.MapGet("/system", () => Results.Ok("app")).RequireAuthorization(AppPolicy);
+                    });
+                }))
+            .StartAsync();
+
+        _client = _host.GetTestClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client.Dispose();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private static HttpRequestMessage Request(string path, params (string type, string value)[] claims)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        var encoded = string.Join("|", claims.Select(c => $"{c.type}={c.value}"));
+        req.Headers.Authorization = new AuthenticationHeaderValue(TestAuthHandler.SchemeName, encoded);
+        return req;
+    }
+
+    [Fact]
+    public async Task OrdersDelegated_Allows_UserTokenWithScpOnly()
+    {
+        var resp = await _client.SendAsync(Request("/whoami", ("scp", "orders.read"), ("oid", "user-1")), TestContext.Current.CancellationToken);
+        resp.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task OrdersDelegated_RejectsTokenWithRoles()
+    {
+        // Mixed token: scp + roles → must be rejected by the delegated policy.
+        var resp = await _client.SendAsync(
+            Request("/whoami", ("scp", "orders.read"), ("roles", "Orders.Process")),
+            TestContext.Current.CancellationToken);
+        resp.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task OrdersDelegated_Rejects_AppToken()
+    {
+        var resp = await _client.SendAsync(Request("/whoami", ("roles", "Orders.Process"), ("azp", AllowedAppId)), TestContext.Current.CancellationToken);
+        resp.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task OrdersApp_Allows_AppTokenWithRolesAndAllowListedAzp()
+    {
+        var resp = await _client.SendAsync(Request("/system", ("roles", "Orders.Process"), ("azp", AllowedAppId)), TestContext.Current.CancellationToken);
+        resp.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task OrdersApp_RejectsTokenWithScp()
+    {
+        // Mixed token: scp + roles → must be rejected by the app policy.
+        var resp = await _client.SendAsync(
+            Request("/system", ("roles", "Orders.Process"), ("scp", "orders.read"), ("azp", AllowedAppId)),
+            TestContext.Current.CancellationToken);
+        resp.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task OrdersApp_Rejects_AppToken_WhenAzpNotAllowListed()
+    {
+        var resp = await _client.SendAsync(Request("/system", ("roles", "Orders.Process"), ("azp", Guid.NewGuid().ToString())), TestContext.Current.CancellationToken);
+        resp.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task OrdersApp_Rejects_UserToken()
+    {
+        var resp = await _client.SendAsync(Request("/system", ("scp", "orders.read")), TestContext.Current.CancellationToken);
+        resp.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+}


### PR DESCRIPTION
Resolves three findings against the auth doctrine in
mghabin/dotnet-engineering-guide/docs/02-aspnetcore.md §10.

1. Orders.Api now exposes two mutually-exclusive named policies
   (OrdersDelegated, OrdersApp) instead of OR-ing scp/roles. Both
   policies reject mixed scp+roles tokens (ch02 §10).
2. EntraAuthJwtPostConfigure pins MapInboundClaims=false plus the
   six TokenValidationParameters validators explicitly so SDK
   default drift can't silently weaken validation (ch02 §10.1).
3. DownstreamApiClient parses WWW-Authenticate on 401/403 and
   throws ClaimsChallengeRequiredException carrying the claims
   parameter so callers can re-acquire with WithClaims (CAE).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
