### PR TITLE
docs(core): Sources + decisive defaults + cross-refs + doctrine alignment (acquisition/validation/best-practices/matrix)

### DIFF
--- a/docs/acquisition.md
+++ b/docs/acquisition.md
@@ -4,7 +4,7 @@ Two flows you ever acquire on the server:
 
 | Flow | Who is the token *for* | Claim shape | OAuth grant |
 |---|---|---|---|
-| **App token** | The calling app/workload | `roles` *(when app roles are assigned/required)*, no `scp`; `idtyp=app` may be present (optional, defense-in-depth) | `client_credentials` (or FIC assertion) |
+| **App token** | The calling app/workload | `roles` *(when app roles are assigned/required)*, no `scp`; `idtyp=app` may not be present (defense-in-depth only — rely on `roles` + `azp` allow-list for enforcement, see [validation.md §4 App-token specific checks](validation.md#4-app-token-specific-checks)) | `client_credentials` (or FIC assertion) |
 | **User token** | The signed-in user | `scp` (delegated scopes); identity in `oid` + `tid` (use these for decisions); `name` / `preferred_username` for display | `authorization_code` (client) → API → **OBO** for downstream |
 
 > Rule of thumb: if there is no human in the request, you want an **app token**. If there is, propagate the user identity via **OBO**, don't fall back to an app token.
@@ -131,7 +131,7 @@ public class MyController(IDownstreamApi downstream) : ControllerBase
 
 What this does: server takes the inbound user token and calls `/oauth2/v2.0/token` with the OBO parameters — `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`, `requested_token_use=on_behalf_of`, and `assertion=<incoming access token>` — plus the API's own client credentials (MI/FIC/cert/secret). It gets back a new user token for the downstream resource; the downstream API still sees a *user* token (with `scp`, user `oid`, etc.).
 
-The credential the API uses to authenticate **itself** to the token endpoint during OBO can be **any** of the credentials in §1 (MI, FIC, cert, secret). Configure under `AzureAd:ClientCredentials`:
+The credential the API uses to authenticate **itself** to the token endpoint during OBO can be **any** of the credentials in §1 (MI, FIC, cert, secret). **Prefer MI when the API runs on Azure compute; FIC when it runs on a non-Azure platform with an OIDC issuer (GitHub Actions, AKS workload identity, EKS/GKE, on-prem k8s).** Cert is acceptable only when neither MI nor FIC is available; secret only as a documented, time-boxed exception. Configure under `AzureAd:ClientCredentials`:
 
 ```jsonc
 "AzureAd": {
@@ -161,7 +161,7 @@ The credential the API uses to authenticate **itself** to the token endpoint dur
 | App registration | `signInAudience: AzureADMyOrg` | `AzureADMultipleOrgs` (or `…AndPersonalMicrosoftAccount`) |
 | Admin consent | Once, in your tenant | Per-tenant; expose via admin-consent URL |
 | App token (`/.default`) | Issued by your tenant | Issued by the **calling tenant** — the app must be provisioned there |
-| OBO | Same-tenant | Token is issued in the **user's** home tenant; downstream must accept that issuer |
+| OBO | Same-tenant | Token is issued in the **user's** home tenant; downstream must accept that issuer. The downstream API **must** enforce a `tid` allow-list via `IssuerValidator` — see [validation.md §3 Issuer & audience](validation.md#3-issuer-audience-v1-vs-v2-single-vs-multi-tenant). |
 | MI / FIC | Same | MI is per-resource in your tenant — to call into other tenants you need a **multi-tenant app reg** + cert/FIC, not raw MI |
 
 Key takeaway: **MI is single-tenant by nature.** For cross-tenant S2S, use a multi-tenant app registration with a cert or FIC, or use MI to call your own multi-tenant app reg's federated credential.
@@ -170,7 +170,38 @@ Key takeaway: **MI is single-tenant by nature.** For cross-tenant S2S, use a mul
 
 ## 4. Token caching — don't get this wrong
 
-- **ASP.NET Core API**: `AddDistributedTokenCaches()` backed by Redis/SQL when running multi-instance. `AddInMemoryTokenCaches()` is fine for single-instance/dev.
-- **Worker**: MSAL's in-memory cache per `IConfidentialClientApplication` instance is fine; **reuse the instance** (singleton). For app tokens, MSAL caches per `(authority, scope)` automatically.
-- **Azure.Identity**: `TokenCredential` already caches; do **not** wrap in your own cache. Reuse a single credential instance.
-- Never cache raw tokens yourself. Never log them.
+App-token caching (S2S / `client_credentials`) and user-token caching (OBO) have different correctness requirements. Treat them separately.
+
+### 4a. App tokens
+
+- MSAL caches app tokens per `(authority, scope)` automatically — you **must** reuse a single `IConfidentialClientApplication` instance (singleton) for caching to take effect.
+- `Azure.Identity` `TokenCredential` already caches internally; **do not** wrap it in your own cache. Reuse a single credential instance per process.
+- In-memory cache is sufficient for app tokens because the cache key is `(authority, scope)` — no per-user partitioning, identical across instances.
+
+### 4b. User tokens (OBO)
+
+- The OBO cache is keyed by the inbound user's identity, so each instance would otherwise re-acquire on first hit. **Distributed cache is mandatory for multi-instance deployments**: `AddDistributedTokenCaches()` backed by Redis or SQL.
+- `AddInMemoryTokenCaches()` is acceptable **only** for single-instance or local dev.
+- An undersized / misconfigured distributed cache will silently fall back to per-instance acquisition; alert on a sudden drop in cache hit-rate. The downstream API still enforces validation per [validation.md](validation.md) — caching does not skip validation.
+
+### 4c. Universal rules
+
+- Never cache raw tokens yourself outside MSAL / `TokenCredential`.
+- Never log raw tokens. Log only the claims you used to authorize (`oid`, `tid`, `azp`, `roles`, `scp`).
+
+---
+
+## Sources
+
+- Microsoft identity platform overview — [learn.microsoft.com/entra/identity-platform/v2-overview](https://learn.microsoft.com/entra/identity-platform/v2-overview)
+- On-Behalf-Of flow — [learn.microsoft.com/entra/identity-platform/v2-oauth2-on-behalf-of-flow](https://learn.microsoft.com/entra/identity-platform/v2-oauth2-on-behalf-of-flow)
+- Client credentials flow — [learn.microsoft.com/entra/identity-platform/v2-oauth2-client-creds-grant-flow](https://learn.microsoft.com/entra/identity-platform/v2-oauth2-client-creds-grant-flow)
+- Managed identities for Azure resources — [learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview)
+- Workload identity federation — [learn.microsoft.com/entra/workload-id/workload-identity-federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+- Microsoft.Identity.Web — [github.com/AzureAD/microsoft-identity-web](https://github.com/AzureAD/microsoft-identity-web)
+- Azure.Identity for .NET — [github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity)
+- MSAL.NET — [github.com/AzureAD/microsoft-authentication-library-for-dotnet](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet)
+- Token caching in MSAL.NET — [learn.microsoft.com/entra/msal/dotnet/how-to/token-cache-serialization](https://learn.microsoft.com/entra/msal/dotnet/how-to/token-cache-serialization)
+- RFC 6749 — The OAuth 2.0 Authorization Framework — [rfc-editor.org/rfc/rfc6749](https://www.rfc-editor.org/rfc/rfc6749)
+- RFC 8693 — OAuth 2.0 Token Exchange — [rfc-editor.org/rfc/rfc8693](https://www.rfc-editor.org/rfc/rfc8693)
+- dotnet-engineering-guide ch02 §10 — auth doctrine — [github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz)

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -2,38 +2,76 @@
 
 Short, opinionated. Defaults that should hold unless you have a specific reason.
 
+Strength markers used below: **must** = no exception without an issue filed; **should** = strong default; **prefer** = pick this when both work; **avoid** = real cost, real risk.
+
+Cross-reference: see [decision-trees.md Tree 4](decision-trees.md#4-does-this-endpoint-accept-delegated-app-only-or-both) for the delegated-vs-app-only routing tree.
+
 ## Credentials
-1. **Order of preference**: Managed Identity → Workload Identity Federation (FIC) → Certificate (KV-backed) → Client Secret. Treat secret as a smell.
-2. Prefer **user-assigned MI** for shared/blue-green infra; system-assigned only when the lifecycle truly matches the resource.
-3. **No secrets in code, repos, env vars, or pipeline variables.** Key Vault + reference, or FIC.
-4. Rotate certs ≤ 12 months, secrets ≤ 6 months, automate it.
-5. One identity per workload — don't share an MI/app reg across unrelated services.
+
+- **must** follow the order of preference: Managed Identity → Workload Identity Federation (FIC) → Certificate (KV-backed) → Client Secret. Treat secret as a smell. (See [credential-patterns/](credential-patterns/index.md#decision-matrix).)
+- **prefer** user-assigned MI for shared/blue-green infra; **should** use system-assigned only when the lifecycle truly matches the resource.
+- **must not** put secrets in code, repos, env vars, or pipeline variables. Use Key Vault + reference, or FIC.
+- **must** rotate certs ≤ 12 months, secrets ≤ 6 months; **should** automate it.
+- **should** use one identity per workload — **avoid** sharing an MI/app reg across unrelated services.
 
 ## Acquisition
-1. Reuse credential / MSAL client / `TokenCredential` instances (singleton). They cache tokens internally.
-2. For app tokens, request `<resource>/.default`, not individual scopes.
-3. For user → downstream, use **OBO**; never substitute an app token for a user token.
-4. In ASP.NET Core, use **`AddDistributedTokenCaches`** when scaled out. `InMemory` only for single-instance/dev.
-5. In workers, use **MSAL.NET** directly; in APIs, use **Microsoft.Identity.Web**; for Azure SDK calls, use **Azure.Identity**.
+
+- **must** reuse credential / MSAL client / `TokenCredential` instances (singleton). They cache tokens internally; a per-request instance defeats the cache.
+- **must** request `<resource>/.default` for app tokens, not individual scopes.
+- **must** use **OBO** for user → downstream calls; **must not** substitute an app token for a user token.
+- **must** use `AddDistributedTokenCaches` in ASP.NET Core when scaled out (OBO cache is per-user — see [acquisition.md §4b](acquisition.md#4b-user-tokens-obo)). `InMemory` only for single-instance/dev.
+- **prefer** library by host: workers → **MSAL.NET** directly; APIs → **Microsoft.Identity.Web**; Azure SDK calls → **Azure.Identity**.
 
 ## Validation
-1. Never disable `ValidateIssuer`, `ValidateAudience`, `ValidateLifetime`, or signature validation.
-2. Pin **audience** explicitly. For **v2** tokens that's the API's **client ID (GUID)**; for **v1** it may be the App ID URI (`api://…`) — accept both during migration.
-3. Authorize on **`scp` for user tokens** and **`roles` for app tokens**, explicitly. Don't share one policy that accepts both silently.
-4. App-only endpoints: also **allow-list `azp`/`appid`**.
-5. Multi-tenant: implement an **`IssuerValidator`** that enforces a tenant allow-list and verifies `tid` matches the issuer's tenant.
-6. Don't use `TenantId: "common"` unless you really accept MSA *and* have a tenant filter.
-7. Honor **CAE** challenges; surface `WWW-Authenticate: Bearer error="insufficient_claims"` from the API and re-acquire on the client.
-8. Use **claims challenges / ACRS** for step-up (MFA, compliant device) on sensitive endpoints — don't bake it into UI logic alone.
+
+- **must not** disable `ValidateIssuer`, `ValidateAudience`, `ValidateLifetime`, or signature validation. No sanctioned exception. (See [validation.md §6](validation.md#6-cross-cutting-keys-clock-cae-acrs).)
+- **must** pin audience explicitly. For **v2** tokens that's the API's **client ID (GUID)**; for **v1** it's the App ID URI (`api://…`) — accept both during migration.
+- **must** authorize delegated and app-only on **separate named policies attached to separate authorization attributes** — never one OR-claims policy. Concretely:
+
+  ```csharp
+  // Doctrine: two policies, two attributes — never OR'd.
+  [Authorize(Policy = "OrdersDelegated")]   // requires scp=orders.read
+  [HttpGet("me/orders")]
+  public IActionResult GetMyOrders() => …
+
+  [Authorize(Policy = "OrdersApp")]         // requires roles=Orders.Process AND azp ∈ allow-list
+  [HttpPost("orders/process")]
+  public IActionResult ProcessAll() => …
+  ```
+
+  Mirrors [dotnet-engineering-guide ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz). See also [decision-trees.md Tree 4](decision-trees.md#4-does-this-endpoint-accept-delegated-app-only-or-both).
+- **must** allow-list `azp`/`appid` on app-only endpoints (defense in depth on top of `roles` — see [validation.md §4](validation.md#4-app-token-specific-checks)).
+- **must** implement an `IssuerValidator` for multi-tenant APIs that enforces a `tid` allow-list and verifies `tid` matches the issuer's tenant. (See [validation.md §3](validation.md#3-issuer-audience-v1-vs-v2-single-vs-multi-tenant).)
+- **must not** use `TenantId: "common"` unless you really accept MSA *and* have a tenant filter. **Prefer** `"organizations"` for SaaS.
+- **must** honor CAE challenges; surface `WWW-Authenticate: Bearer error="insufficient_claims"` from the API and re-acquire on the client (per [RFC 6750 §3](https://www.rfc-editor.org/rfc/rfc6750#section-3)).
+- **should** use claims challenges / ACRS for step-up (MFA, compliant device) on sensitive endpoints — **avoid** baking step-up into UI logic alone.
 
 ## App registration / tenant hygiene
-1. Define **app roles** for S2S; don't reuse delegated scopes for app permissions.
-2. Grant the minimum app role to the minimum SP (the MI's SP, the worker's app reg) — least privilege.
-3. Use separate app registrations for separate environments (dev/test/prod). Don't share secrets across rings.
-4. For multi-tenant SaaS: keep an **explicit list** of provisioned tenants; provision via admin consent, deprovision on offboarding.
+
+- **must** define app roles for S2S; **must not** reuse delegated scopes for app permissions.
+- **must** grant the minimum app role to the minimum SP (the MI's SP, the worker's app reg) — least privilege.
+- **must** use separate app registrations for separate environments (dev/test/prod). **Must not** share secrets across rings.
+- **must** keep an explicit list of provisioned tenants for multi-tenant SaaS; provision via admin consent, deprovision on offboarding.
 
 ## Operational
-1. Log **claims you used to authorize** (`oid`, `tid`, `azp`, `roles`, `scp`) — never log the raw token.
-2. Emit metrics on auth failures by reason (`invalid_audience`, `invalid_issuer`, `missing_role`, `cae_challenge`).
-3. Alert on sudden drops in token-cache hit-rate (often a misconfigured singleton).
-4. Test the validation pipeline with **negative tests**: wrong audience, wrong tenant, expired, missing role, app token where user expected, user token where app expected.
+
+- **must** log the claims used to authorize (`oid`, `tid`, `azp`, `roles`, `scp`); **must not** log raw tokens.
+- **should** emit metrics on auth failures by reason (`invalid_audience`, `invalid_issuer`, `missing_role`, `cae_challenge`).
+- **should** alert on sudden drops in token-cache hit-rate (often a misconfigured singleton).
+- **must** test the validation pipeline with negative tests: wrong audience, wrong tenant, expired, missing role, app token where user expected, user token where app expected.
+
+---
+
+## Sources
+
+- dotnet-engineering-guide ch02 §10 — auth doctrine (separate policies, no OR-claims) — [github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz)
+- infra-engineering-guide ch06 §3 — workload identity / no static credentials — [github.com/mghabin/infra-engineering-guide/blob/main/docs/06-security-supply-chain.md#3-workload-identity--the-no-static-credentials-rule](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/06-security-supply-chain.md#3-workload-identity--the-no-static-credentials-rule)
+- Microsoft Entra access token claims reference — [learn.microsoft.com/entra/identity-platform/access-token-claims-reference](https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference)
+- Managed identities for Azure resources — [learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview)
+- Workload identity federation — [learn.microsoft.com/entra/workload-id/workload-identity-federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+- App roles — [learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps](https://learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps)
+- Microsoft.Identity.Web — [github.com/AzureAD/microsoft-identity-web](https://github.com/AzureAD/microsoft-identity-web)
+- RFC 6749 — OAuth 2.0 Authorization Framework — [rfc-editor.org/rfc/rfc6749](https://www.rfc-editor.org/rfc/rfc6749)
+- RFC 6750 — Bearer Token Usage — [rfc-editor.org/rfc/rfc6750](https://www.rfc-editor.org/rfc/rfc6750)
+- RFC 7519 — JSON Web Token (JWT) — [rfc-editor.org/rfc/rfc7519](https://www.rfc-editor.org/rfc/rfc7519)
+- OWASP ASVS v4 §3 (Session Management) and §4 (Access Control) — [owasp.org/www-project-application-security-verification-standard](https://owasp.org/www-project-application-security-verification-standard/)

--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -13,9 +13,10 @@ One row per realistic backend scenario. "Validation" assumes the receiving API u
 | 7 | On-prem worker calls Graph | App | MSAL.NET | **Certificate** (KV-backed) → `WithCertificate(cert)` (add `sendX5C: true` only for SNI / x5c cert-rollover) | `roles`, `azp` | Cert in source tree; no rotation; cargo-culting `sendX5C` when not needed |
 | 8 | Legacy daemon, MI/FIC not possible | App | MSAL.NET | **Client secret** (KV) | `roles`, `azp` | Long-lived secret; secret in env var on dev box |
 | 9 | API in Azure calls Storage / Key Vault / Cosmos | App (Azure resource) | **Azure.Identity** (`DefaultAzureCredential`) on the SDK client | MI in prod, CLI/VS in dev | n/a (Azure RBAC, not your API) | Wrapping `TokenCredential` in your own cache; using account keys |
-| 10 | Multi-tenant SaaS API | User and/or App | Microsoft.Identity.Web | API's own: MI / FIC / cert | `IssuerValidator` with **tenant allow-list**; `tid` matches issuer; `roles`/`scp` | `TenantId: "common"` with no tenant filter (open door); admin-consent flow forgotten |
-| 11 | API exposed to both users and apps | Both | Microsoft.Identity.Web | — | Branch on `idtyp`/`scp` vs `roles`; separate authorization policies | One `[Authorize]` policy that silently accepts either |
+| 10 | Multi-tenant SaaS API | User and/or App | Microsoft.Identity.Web | API's own: MI / FIC / cert | `IssuerValidator` with **tenant allow-list**; `tid` matches issuer; `roles`/`scp` (see [validation.md §3](validation.md#3-issuer-audience-v1-vs-v2-single-vs-multi-tenant)) | `TenantId: "common"` with no tenant filter (open door); admin-consent flow forgotten |
+| 11 | API exposed to both users and apps | Both | Microsoft.Identity.Web | — | **Two separate named policies on two separate `[Authorize]` attributes** — never one OR-claims policy. Per [dotnet-engineering-guide ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz) and [decision-trees.md Tree 4](decision-trees.md#4-does-this-endpoint-accept-delegated-app-only-or-both). | One `[Authorize]` policy that silently accepts either |
 | 12 | Cross-tenant S2S (your app calling a partner tenant) | App | MSAL.NET | **Multi-tenant app reg + cert/FIC** (MI cannot do this) | partner validates `roles` granted in *their* tenant | Trying to use MI; partner hasn't consented your app |
+| 13 | API receives token from another API (pass-through pattern) | App or User | n/a (token already inbound) | n/a | **Validate, don't cache**: full signature/audience/issuer/`roles`+`azp` (or `scp`) checks per [validation.md](validation.md). The intermediate API **must not** re-mint or cache the inbound token; if it needs to call further downstream as the same user, use **OBO** ([acquisition.md §2b](acquisition.md#2b-calling-a-downstream-api-as-that-user-obo)) — never replay the raw token. | Forwarding the raw inbound token to a downstream API; trusting the upstream's claims without re-validating signature |
 
 ## Quick "which credential" by host
 
@@ -32,8 +33,29 @@ One row per realistic backend scenario. "Validation" assumes the receiving API u
 
 ## "Which library" by call target
 
-| You're calling… | Library |
-|---|---|
-| Azure resource SDK (Storage, KV, Cosmos, Service Bus, Graph SDK using `TokenCredential`) | **Azure.Identity** |
-| Your own / 3rd-party Entra-protected REST API from a worker | **MSAL.NET** |
-| Downstream API from inside an ASP.NET Core API (incl. OBO) | **Microsoft.Identity.Web** |
+Decisive picks — these libraries are not interchangeable. Pick by call target, not preference.
+
+| You're calling… | Library | Why |
+|---|---|---|
+| Azure resource SDK (Storage, KV, Cosmos, Service Bus, Graph SDK using `TokenCredential`) | **Azure.Identity** | Designed for `TokenCredential`-aware Azure SDKs; integrates with MI / `DefaultAzureCredential` chain. |
+| Your own / 3rd-party Entra-protected REST API from a worker | **MSAL.NET** | Arbitrary OAuth flows incl. `client_credentials`, `WithClientAssertion` (FIC), and OBO. Not bound to ASP.NET Core. |
+| Downstream API from inside an ASP.NET Core API (incl. OBO) | **Microsoft.Identity.Web** | Wraps MSAL.NET + JwtBearer wiring; `ITokenAcquisition` / `IDownstreamApi` / distributed token cache integration. |
+
+If you find yourself using MSAL.NET to call Azure Storage, or `Azure.Identity` to do OBO, you've picked the wrong library — re-derive from the table.
+
+---
+
+## Sources
+
+- Microsoft identity platform overview — [learn.microsoft.com/entra/identity-platform/v2-overview](https://learn.microsoft.com/entra/identity-platform/v2-overview)
+- On-Behalf-Of flow — [learn.microsoft.com/entra/identity-platform/v2-oauth2-on-behalf-of-flow](https://learn.microsoft.com/entra/identity-platform/v2-oauth2-on-behalf-of-flow)
+- Managed identities for Azure resources — [learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview)
+- Workload identity federation — [learn.microsoft.com/entra/workload-id/workload-identity-federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+- Azure Workload Identity (AKS) — [learn.microsoft.com/azure/aks/workload-identity-overview](https://learn.microsoft.com/azure/aks/workload-identity-overview)
+- Microsoft.Identity.Web — [github.com/AzureAD/microsoft-identity-web](https://github.com/AzureAD/microsoft-identity-web)
+- MSAL.NET — [github.com/AzureAD/microsoft-authentication-library-for-dotnet](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet)
+- Azure.Identity for .NET — [github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity)
+- dotnet-engineering-guide ch02 §10 — auth doctrine — [github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz)
+- infra-engineering-guide ch06 §3 — workload identity — [github.com/mghabin/infra-engineering-guide/blob/main/docs/06-security-supply-chain.md#3-workload-identity--the-no-static-credentials-rule](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/06-security-supply-chain.md#3-workload-identity--the-no-static-credentials-rule)
+- RFC 6749 — OAuth 2.0 — [rfc-editor.org/rfc/rfc6749](https://www.rfc-editor.org/rfc/rfc6749)
+- RFC 8693 — OAuth 2.0 Token Exchange — [rfc-editor.org/rfc/rfc8693](https://www.rfc-editor.org/rfc/rfc8693)

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -32,8 +32,8 @@ builder.Services.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationSch
 {
     o.TokenValidationParameters.ValidAudiences = new[]
     {
-        "<api-app-id-guid>",          // v2 default: the API's client ID
-        "api://<api-app-id-uri>"      // v1 may use the App ID URI; include during v1↔v2 migration
+        "<api-app-id-guid>",          // v2 default: the API's client ID (GUID)
+        "api://<api-app-id-uri>"      // v1 default: the App ID URI — include both during v1↔v2 migration
     };
 });
 ```
@@ -94,7 +94,7 @@ Microsoft.Identity.Web replaces the simple `ValidIssuer` check with `IssuerValid
 - Accepts `https://login.microsoftonline.com/{tenantId}/v2.0` for **any** tenant.
 - Verifies that `tid` claim matches the issuer's tenant segment.
 
-You still need to decide **which tenants you allow**. For SaaS, store the list of customer tenants and reject others:
+You still need to decide **which tenants you allow**. For SaaS, store the list of customer tenants and reject others. The rejection contract is explicit: if `tid` is not in the allow-list (or doesn't match the issuer's tenant segment), throw `SecurityTokenInvalidIssuerException` — Microsoft.Identity.Web translates this to **HTTP 401 Unauthorized** (not 403; 403 is reserved for "authenticated but lacks permission"):
 
 ```csharp
 o.TokenValidationParameters.IssuerValidator = (issuer, token, parameters) =>
@@ -110,13 +110,14 @@ o.TokenValidationParameters.IssuerValidator = (issuer, token, parameters) =>
 
 ## 4. App-token specific checks
 
-Beyond `roles`, apply:
+Beyond the standard signature/audience/issuer/lifetime checks, an app-only endpoint enforces authorization in two layers:
 
-- **`azp` / `appid` allow-list** (primary defense) — the calling client's app ID. Maintain an allow-list of client app IDs that may call this endpoint. Don't rely solely on roles if the role is broad.
-- **No `scp` claim** — defense in depth (a true app token never has `scp`).
-- **`idtyp == "app"`** — *optional* additional signal; the claim is not always emitted, so don't rely on it as a required check.
+- **`roles` (PRIMARY — RBAC)** — the app role(s) you defined on the API and granted to the calling SP. This is the authorization decision. Configure `appRoleAssignmentRequired = true` on the API's enterprise app so Entra refuses to mint a token without an assignment. Don't assume `roles` will be present just because the token is app-only — only granted roles appear.
+- **`azp` / `appid` allow-list (SECONDARY — defense in depth)** — the calling client's app ID. Maintain an allow-list of client app IDs that may call this endpoint. This catches mis-grants where a role was assigned more broadly than intended.
+- **No `scp` claim** — additional defense in depth: a true app token never has `scp`. Reject if present.
+- **`idtyp == "app"`** — *optional* signal only; the claim is not always emitted, so **never** rely on it as a required check. Use it as a hint, not a gate.
 
-Note on `roles`: an app-only token only contains `roles` if you've defined app roles on the API and granted them to the calling SP (and `appRoleAssignmentRequired = true` is recommended). Don't assume `roles` will be present just because the token is app-only.
+Doctrine: `roles` is the authorization decision; `azp` is a circuit-breaker. Mirrors [dotnet-engineering-guide ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz) — separate named policies per identity model, **never** an OR-claims policy.
 
 ```csharp
 var appId = User.FindFirst("azp")?.Value      // v2
@@ -142,10 +143,10 @@ There is nothing magical to validate about MI tokens; treat them like any S2S ca
 
 - **Signing keys**: pulled from `https://login.microsoftonline.com/<tenant>/v2.0/.well-known/openid-configuration` and rotated automatically. Do not pin keys.
 - **Clock skew**: default 5 min — leave it.
-- **CAE (Continuous Access Evaluation)**: opt-in, lets Entra invalidate tokens early on conditional-access events. Microsoft.Identity.Web supports it via `WithClientCapabilities(["cp1"])` on the client and by surfacing `WWW-Authenticate: Bearer error="insufficient_claims"` from the API. Honor it.
-- **ACRS / claims challenges**: for step-up auth (e.g., MFA required for a sensitive endpoint), the API must return **401** with a `WWW-Authenticate: Bearer error="insufficient_claims", claims="<base64url-json>"` header so the client re-acquires a token satisfying the policy. Use Microsoft.Identity.Web helpers — e.g. `HttpContext.GetTokenAcquirer().ReplyForbiddenWithWwwAuthenticateHeaderAsync(...)` or build the header via `WwwAuthenticateParameters` — rather than throwing a bare exception (which won't include the `claims` parameter).
+- **CAE (Continuous Access Evaluation)**: opt-in, lets Entra invalidate tokens early on conditional-access events. Microsoft.Identity.Web supports it via `WithClientCapabilities(["cp1"])` on the client and by surfacing `WWW-Authenticate: Bearer error="insufficient_claims"` from the API per [RFC 6750 §3.1](https://www.rfc-editor.org/rfc/rfc6750#section-3.1). Honor it.
+- **ACRS / claims challenges**: for step-up auth (e.g., MFA required for a sensitive endpoint), the API must return **401** with a `WWW-Authenticate: Bearer error="insufficient_claims", claims="<base64url-json>"` header so the client re-acquires a token satisfying the policy. Format follows [RFC 6750 §3.1](https://www.rfc-editor.org/rfc/rfc6750#section-3.1); error bodies should follow [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457). Use Microsoft.Identity.Web helpers — e.g. `HttpContext.GetTokenAcquirer().ReplyForbiddenWithWwwAuthenticateHeaderAsync(...)` or build the header via `WwwAuthenticateParameters` — rather than throwing a bare exception (which won't include the `claims` parameter).
 - **Multi-audience APIs**: list every accepted audience in `ValidAudiences`. Never disable audience validation.
-- **Don't** disable `ValidateIssuer`, `ValidateAudience`, or `ValidateLifetime`. Ever.
+- **Must always validate** `ValidateIssuer`, `ValidateAudience`, `ValidateLifetime`, and signature. **No sanctioned exception.** If you think you need one, file an issue first — the answer is almost always "no, you have a bug elsewhere."
 
 ---
 
@@ -158,3 +159,20 @@ There is nothing magical to validate about MI tokens; treat them like any S2S ca
 - [ ] Multi-tenant: tenant allow-list enforced in `IssuerValidator`.
 - [ ] Audience set explicitly to App ID URI (and GUID during v1↔v2 migration).
 - [ ] CAE enabled if calling Entra-protected downstream APIs.
+
+---
+
+## Sources
+
+- RFC 7519 — JSON Web Token (JWT) — [rfc-editor.org/rfc/rfc7519](https://www.rfc-editor.org/rfc/rfc7519)
+- RFC 6750 — The OAuth 2.0 Authorization Framework: Bearer Token Usage — [rfc-editor.org/rfc/rfc6750](https://www.rfc-editor.org/rfc/rfc6750) (esp. §3 `WWW-Authenticate` Response Header Field)
+- RFC 9457 — Problem Details for HTTP APIs — [rfc-editor.org/rfc/rfc9457](https://www.rfc-editor.org/rfc/rfc9457)
+- OpenID Connect Core 1.0 — [openid.net/specs/openid-connect-core-1_0.html](https://openid.net/specs/openid-connect-core-1_0.html)
+- Microsoft Entra access token claims reference — [learn.microsoft.com/entra/identity-platform/access-token-claims-reference](https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference)
+- Token version (`requestedAccessTokenVersion`) — [learn.microsoft.com/entra/identity-platform/access-tokens#token-formats](https://learn.microsoft.com/entra/identity-platform/access-tokens#token-formats)
+- Microsoft.Identity.Web — multi-tenant web APIs — [github.com/AzureAD/microsoft-identity-web/wiki/multi-tenant-web-apis](https://github.com/AzureAD/microsoft-identity-web/wiki/multi-tenant-web-apis)
+- Microsoft.Identity.Web — [github.com/AzureAD/microsoft-identity-web](https://github.com/AzureAD/microsoft-identity-web)
+- Continuous Access Evaluation (CAE) — [learn.microsoft.com/entra/identity/conditional-access/concept-continuous-access-evaluation](https://learn.microsoft.com/entra/identity/conditional-access/concept-continuous-access-evaluation)
+- Claims challenges, claims requests, and client capabilities — [learn.microsoft.com/entra/identity-platform/claims-challenge](https://learn.microsoft.com/entra/identity-platform/claims-challenge)
+- App roles — [learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps](https://learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps)
+- dotnet-engineering-guide ch02 §10 — auth doctrine — [github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz)


### PR DESCRIPTION
- acquisition.md: split app-token vs user-token (OBO) caching guidance,
  drop hedging on idtyp (defense-in-depth only), cross-link multi-tenant
  OBO row to validation.md IssuerValidator section, prefer MI/FIC for the
  API's own credential, add Sources block.
- validation.md: reorder §4 so roles is the PRIMARY (RBAC) decision and
  azp allow-list is SECONDARY defense, spell out IssuerValidator
  rejection contract (SecurityTokenInvalidIssuerException → HTTP 401),
  cite RFC 6750 §3 + RFC 9457 for CAE/ACRS error format, tighten
  Validate* rule to 'no sanctioned exception', add Sources block.
- best-practices.md: add must/should/prefer/avoid strength markers on
  every rule, add concrete two-policy/two-attribute example for
  delegated vs app-only (citing dotnet-engineering-guide ch02 §10),
  anchor links to validation.md sections and decision-trees Tree 4,
  add Sources block.
- matrix.md: add row 13 'API receives token from another API'
  (validate-don't-cache, OBO not replay), anchor multi-tenant row to
  validation.md §3, cite ch02 §10 doctrine on delegated-vs-app row,
  expand 'which library' table with rationale, add Sources block.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
