### PR TITLE
docs(cred-patterns): Sources + decisive defaults + doctrine (index/MI/FIC/cert/client-secret)

### DIFF
--- a/docs/credential-patterns/cert.md
+++ b/docs/credential-patterns/cert.md
@@ -30,6 +30,11 @@ public key and issues an access token.
 var cert = X509CertificateLoader.LoadPkcs12FromFile(
     "/path/to/cert.pfx",
     password: null,
+    // EphemeralKeySet: hold the private key in process memory only;
+    // do NOT persist a copy to the user/machine keystore on disk.
+    // Required on Linux containers and recommended everywhere — it
+    // prevents stale key material from leaking to the host filesystem
+    // across container restarts and avoids ACL drift on Windows.
     keyStorageFlags: X509KeyStorageFlags.EphemeralKeySet);
 
 var credential = new ClientCertificateCredential(
@@ -65,6 +70,28 @@ var credential = new ClientCertificateCredential(
     tenantId, clientId, cert);
 ```
 
+## Rotation cadence
+
+- **Must** rotate at least annually. The Entra app-registration UI
+  permits up to 24 months on certificate credentials; **don't** use
+  the maximum.
+- **Best practice: rotate every 90 days** (matches the Let's Encrypt
+  / public-CA cadence and the `openssl req -days 90 …` example below).
+  Short lifetimes mean a leaked private key is useful to an attacker
+  for a bounded window.
+- **Should** automate via Azure Key Vault certificate auto-renewal +
+  an event-grid hook that reuploads the new public-key portion to the
+  Entra app reg via `az ad app credential reset --id $APP_ID --cert @cert.pem`.
+  Manual rotation is error-prone: the failure mode is "expired cert in
+  prod at 03:00" because the rotation runbook lived in someone's
+  bookmarks.
+- **Must** keep `notBefore` overlap windows (publish the new cert
+  before retiring the old) so that in-flight requests don't see a
+  rejected `kid`. Entra accepts multiple cert credentials per app reg
+  for exactly this reason.
+- **Must** monitor cert expiry. `az ad app credential list --id $APP_ID`
+  in a scheduled job, alerting at T-30d / T-7d / T-1d.
+
 ## Setup
 
 1. Generate a cert (`openssl req -x509 -newkey rsa:2048 -days 90 …`).
@@ -84,3 +111,26 @@ adding nothing except more things to rotate.
 We kept the pattern in this doc because the on-prem and HSM-bound
 scenarios are real. We dropped the deployed service because it
 taught the wrong default for cloud.
+
+## Cross-references
+
+- Acquisition wiring (which library, scope strings) — [`acquisition.md` §1c](../acquisition.md#1c-certificate-on-an-app-registration--acceptable-when-mific-unavailable).
+- Rotation as a cross-cutting operational concern — [`best-practices.md` — Credentials](../best-practices.md#credentials).
+- Picker decision (when MI vs FIC vs cert) — [`index.md`](index.md#decision-matrix).
+- Sibling credential patterns — [`managed-identity.md`](managed-identity.md), [`federated-identity.md`](federated-identity.md), [`client-secret.md`](client-secret.md).
+- Per-scenario credential picker — [`matrix.md`](../matrix.md).
+- Auth-policy doctrine (delegated vs app-only) — dotnet-engineering-guide [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz).
+
+---
+
+## Sources
+
+- Microsoft identity platform — Certificate credentials for application authentication — [learn.microsoft.com/entra/identity-platform/certificate-credentials](https://learn.microsoft.com/entra/identity-platform/certificate-credentials)
+- `ClientCertificateCredential` reference — [learn.microsoft.com/dotnet/api/azure.identity.clientcertificatecredential](https://learn.microsoft.com/dotnet/api/azure.identity.clientcertificatecredential)
+- `X509KeyStorageFlags.EphemeralKeySet` — [learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.x509keystorageflags](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.x509keystorageflags)
+- Azure Key Vault — Certificate auto-renewal — [learn.microsoft.com/azure/key-vault/certificates/tutorial-rotate-certificates](https://learn.microsoft.com/azure/key-vault/certificates/tutorial-rotate-certificates)
+- OWASP — Cryptographic Storage Cheat Sheet — [cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
+- OWASP — Key Management Cheat Sheet — [cheatsheetseries.owasp.org/cheatsheets/Key_Management_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/Key_Management_Cheat_Sheet.html)
+- NIST SP 800-57 Part 1 Rev. 5 — Recommendation for Key Management — [nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf)
+- FIPS 140-2 — Security Requirements for Cryptographic Modules — [csrc.nist.gov/publications/detail/fips/140/2/final](https://csrc.nist.gov/publications/detail/fips/140/2/final)
+- PCI DSS v4.0 — Requirement 3 (key management) — [pcisecuritystandards.org/document_library/](https://www.pcisecuritystandards.org/document_library/)

--- a/docs/credential-patterns/client-secret.md
+++ b/docs/credential-patterns/client-secret.md
@@ -29,8 +29,12 @@ var credential = new ClientSecretCredential(
 2. **Rotation is a maintenance burden** that gets neglected. Most
    leaked-secret incidents involve a secret older than the engineer
    who left it.
-3. **Limited TTL.** Entra caps client secret lifetimes at 24 months
-   (recently shortened from infinite). Forced rotation cycles
+3. **Limited TTL.** Entra caps client-secret lifetimes at **24 months
+   maximum** (see [Microsoft Learn — App registration credential best
+   practices](https://learn.microsoft.com/entra/identity-platform/app-registration-best-practices#client-secret-lifetime)),
+   recently shortened from "no enforced cap." **Rotate at 6 months
+   even if Entra permits longer** — the maximum exists to bound a
+   leak, not to recommend long lifetimes. Forced rotation cycles
    regularly. With MI or FIC there's nothing to rotate.
 4. **Audit story is bad.** A token request signed by a secret tells
    the audit log nothing about *which workload* made the request.
@@ -41,13 +45,31 @@ var credential = new ClientSecretCredential(
 
 ## When it's actually OK
 
-- Local dev where the workload genuinely cannot use MI / FIC and
-  doing so would block iteration.
-- Quick spike / proof-of-concept code with a 1-hour TTL secret in a
-  scratch tenant. Delete after.
-- Migrating a legacy system: secret stays as the "before" while you
-  build the cert/FIC/MI replacement; secret gets revoked the moment
-  the migration cuts over.
+Three documented exceptions, in priority order. **If your case isn't on this list, you don't have an exception.**
+
+- **Local dev** where the workload genuinely cannot use MI / FIC and
+  doing so would block iteration. Prefer `DefaultAzureCredential` →
+  `az login` first; secret only if that path is also unavailable.
+- **Quick spike / proof-of-concept** code with a 1-hour TTL secret in
+  a scratch tenant. Delete after.
+- **Migrating a legacy system**: secret stays as the "before" while
+  you build the cert/FIC/MI replacement; secret gets revoked the
+  moment the migration cuts over.
+
+### Hybrid runtime workloads (cloud + on-prem fallback)
+
+If the same workload runs in cloud *and* falls back to on-prem (DR
+site, edge POP, regulated tenant), **must not** share a single client
+secret across environments to "simplify config." That collapses the
+blast radius of a leak from one environment to all of them, and makes
+rotation an all-or-nothing outage.
+
+- **Should** use FIC where the runtime can present an OIDC token (the
+  cloud half almost always can).
+- **May** fall back to a certificate credential for the on-prem half
+  (per [`cert.md`](cert.md)).
+- **Must not** share secrets across cloud and on-prem. Different
+  environments → different app registrations → different credentials.
 
 ## Why we used to ship this and don't anymore
 
@@ -64,3 +86,26 @@ If you find this pattern in your codebase, the migration path is:
 3. Cut over and revoke the secret in Entra.
 4. Delete the env var, the secret-fetching code, and the secret
    from any KV / config store.
+
+## Cross-references
+
+- Acquisition wiring (last-resort path, library choices) — [`acquisition.md` §1d](../acquisition.md#1d-client-secret--last-resort).
+- Receiver-side validation (`azp` allow-list applies regardless of credential) — [`validation.md` §4](../validation.md#4-app-token-specific-checks).
+- Rotation as a cross-cutting operational concern — [`best-practices.md` — Credentials](../best-practices.md#credentials).
+- Picker decision (when MI vs FIC vs cert vs secret) — [`index.md`](index.md#decision-matrix).
+- Sibling credential patterns — [`managed-identity.md`](managed-identity.md), [`federated-identity.md`](federated-identity.md), [`cert.md`](cert.md).
+- Auth-policy doctrine (delegated vs app-only) — dotnet-engineering-guide [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz).
+
+---
+
+## Sources
+
+- App registration credential best practices (24-month max, rotation) — [learn.microsoft.com/entra/identity-platform/app-registration-best-practices#client-secret-lifetime](https://learn.microsoft.com/entra/identity-platform/app-registration-best-practices#client-secret-lifetime)
+- Microsoft Entra — Sign-in logs (audit trail for client-credentials grants) — [learn.microsoft.com/entra/identity/monitoring-health/concept-sign-ins](https://learn.microsoft.com/entra/identity/monitoring-health/concept-sign-ins)
+- Microsoft Entra — Audit logs — [learn.microsoft.com/entra/identity/monitoring-health/concept-audit-logs](https://learn.microsoft.com/entra/identity/monitoring-health/concept-audit-logs)
+- `ClientSecretCredential` reference — [learn.microsoft.com/dotnet/api/azure.identity.clientsecretcredential](https://learn.microsoft.com/dotnet/api/azure.identity.clientsecretcredential)
+- GitHub — About secret scanning — [docs.github.com/code-security/secret-scanning/about-secret-scanning](https://docs.github.com/code-security/secret-scanning/about-secret-scanning)
+- GitHub — Push protection for secrets — [docs.github.com/code-security/secret-scanning/push-protection-for-repositories-and-organizations](https://docs.github.com/code-security/secret-scanning/push-protection-for-repositories-and-organizations)
+- OWASP — Secrets Management Cheat Sheet — [cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)
+- PCI DSS v4.0 — Requirement 3 (protect stored account data) and 8 (authentication) — [pcisecuritystandards.org/document_library/](https://www.pcisecuritystandards.org/document_library/)
+- RFC 6749 §2.3.1 — Client Password (the symmetric-secret threat model) — [rfc-editor.org/rfc/rfc6749#section-2.3.1](https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1)

--- a/docs/credential-patterns/federated-identity.md
+++ b/docs/credential-patterns/federated-identity.md
@@ -54,10 +54,23 @@ az ad app federated-credential create \
 
 The `subject` claim is the most security-critical setting. Use the
 narrowest possible value:
-- For a specific branch: `repo:owner/repo:ref:refs/heads/main`
-- For a specific environment: `repo:owner/repo:environment:prod`
-- **Never** use `repo:owner/repo:*` or other wildcards in production —
-  any PR could acquire prod tokens.
+
+- For a specific branch: `repo:owner/repo:ref:refs/heads/main` — **must** use this for production.
+- For a specific environment: `repo:owner/repo:environment:prod` — **must** combine with a GitHub environment that has required-reviewers / branch-restriction rules.
+- **Never** use wildcard subjects (`repo:owner/repo:*`, `repo:owner/repo:pull_request`, or claim-mapping that ignores `sub`) for any credential that can reach a non-throwaway tenant.
+
+**Why wildcards are dangerous.** A wildcard subject says "trust *any*
+OIDC token from this repository, regardless of which branch / PR /
+workflow minted it." That collapses the entire branch-protection
+model: any contributor who can open a pull request can author a
+workflow file in their PR branch that runs on `pull_request` events,
+mints an OIDC token with subject `repo:owner/repo:pull_request`, and
+exchanges it for a prod Entra access token — with no review, no
+required approvers, no environment gate. The FIC subject is the *only*
+thing standing between "anyone with PR rights" and "anyone with prod
+credentials." Pin it. The same rule applies to GitLab (`project_path`,
+`ref`, `ref_type`), Bitbucket (`workspaceUuid:repositoryUuid:…`),
+and Kubernetes service accounts (`system:serviceaccount:ns:sa-name`).
 
 ## Where this sample uses FIC
 
@@ -66,13 +79,31 @@ narrowest possible value:
    token to call this sample's RestaurantsApi.
 2. **CD pipeline** — `azure/login` in `cd.yml` uses FIC to deploy
    bicep without storing a service principal secret.
-3. **`SignedAssertionFromManagedIdentity` (BFF)** — this is *also*
-   a federated identity credential, with the federation source being
-   an Azure Managed Identity instead of an external IdP. The BFF
-   uses its MI to mint a token whose issuer is the tenant's STS,
-   and the BFF app reg has a FIC trusting that issuer/subject. This
-   is how a confidential web client running on Azure can do OBO
-   without a secret.
+3. **`SignedAssertionFromManagedIdentity` (BFF)** — superficially
+   "federation," but **not** OIDC-FIC. This is
+   `Microsoft.Identity.Web.SignedAssertionFromManagedIdentity`: a
+   delegate that uses a Managed Identity to sign a JWT assertion which
+   the BFF then submits as the `client_assertion` for an app
+   registration's `client_credentials` grant. **The issuer of that
+   assertion is the tenant STS, not an external OIDC provider.** The
+   app registration carries a federated-identity-credential entry
+   trusting the MI's issuer/subject (intra-tenant). Concretely:
+   - True OIDC-FIC (cases 1 and 2 above): issuer is *outside* Entra
+     (`token.actions.githubusercontent.com`, `gitlab.com`,
+     `kubernetes.default.svc`, …), audience is
+     `api://AzureADTokenExchange`, the federated source is a separate
+     identity provider.
+   - `SignedAssertionFromManagedIdentity` (this case): issuer is
+     `https://login.microsoftonline.com/{tenant}/v2.0` (the tenant's
+     own STS), the federated source is an Azure Managed Identity in the
+     same tenant, and the FIC on the app reg is configured with that
+     MI as the trusted issuer. It lets a confidential web client
+     running on Azure perform OBO without a stored client secret, by
+     proxying the MI's identity into a `client_assertion`.
+
+   See [`glossary.md` — SignedAssertionFromManagedIdentity](../../glossary.md#signedassertionfrommanagedidentity)
+   for the canonical definition. Mistaking the two swaps the
+   credential model — see [`coverage-map.md` row "SignedAssertionFromManagedIdentity (BFF token-exchange) — not OIDC-FIC"](../../coverage-map.md).
 
 ## Why this is the default for non-Azure compute
 
@@ -82,3 +113,28 @@ narrowest possible value:
 - **Granular scoping.** Subject claim can pin trust to a specific
   branch / environment / pod / cluster — much finer than "this
   service has the secret."
+
+## Cross-references
+
+- Acquisition wiring (which library, scope strings, when to use OBO) — [`acquisition.md` §1b](../acquisition.md#1b-workload-identity-federation-fic--preferred-outside-azure).
+- Receiver-side validation of FIC-acquired app tokens (`azp`, `roles`) — [`validation.md` §4](../validation.md#4-app-token-specific-checks).
+- Per-environment app-reg / FIC creation in CI — [`deploy-cloud.md`](../deploy-cloud.md).
+- Picker decision (when MI vs FIC vs cert) — [`index.md`](index.md#decision-matrix).
+- Sibling credential patterns — [`managed-identity.md`](managed-identity.md), [`cert.md`](cert.md), [`client-secret.md`](client-secret.md).
+- Glossary disambiguation — [`glossary.md` — Federated Identity Credential](../../glossary.md#federated-identity-credential-fic) vs [`glossary.md` — SignedAssertionFromManagedIdentity](../../glossary.md#signedassertionfrommanagedidentity).
+- Auth-policy doctrine (delegated vs app-only, never OR-claims) — dotnet-engineering-guide [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz).
+
+---
+
+## Sources
+
+- Workload identity federation — overview — [learn.microsoft.com/entra/workload-id/workload-identity-federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+- Configure a federated identity credential on an app — [learn.microsoft.com/entra/workload-id/workload-identity-federation-create-trust](https://learn.microsoft.com/entra/workload-id/workload-identity-federation-create-trust)
+- Federated identity credential considerations (subject formats, supported issuers) — [learn.microsoft.com/entra/workload-id/workload-identity-federation-considerations](https://learn.microsoft.com/entra/workload-id/workload-identity-federation-considerations)
+- GitHub — About security hardening with OpenID Connect — [docs.github.com/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect](https://docs.github.com/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
+- GitHub — Configuring OpenID Connect in Azure — [docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure](https://docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure)
+- Microsoft.Identity.Web — Managed identity as a federated credential — [github.com/AzureAD/microsoft-identity-web/wiki/Using-managed-identity-as-a-federated-identity-credential](https://github.com/AzureAD/microsoft-identity-web/wiki/Using-managed-identity-as-a-federated-identity-credential)
+- RFC 8693 — OAuth 2.0 Token Exchange — [rfc-editor.org/rfc/rfc8693](https://www.rfc-editor.org/rfc/rfc8693)
+- OpenID Connect Core 1.0 — [openid.net/specs/openid-connect-core-1_0.html](https://openid.net/specs/openid-connect-core-1_0.html)
+- SPIFFE — Secure Production Identity Framework for Everyone — [spiffe.io/docs/latest/spiffe-about/overview](https://spiffe.io/docs/latest/spiffe-about/overview)
+- SPIFFE — SVID specification — [github.com/spiffe/spiffe/blob/main/standards/SPIFFE-ID.md](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE-ID.md)

--- a/docs/credential-patterns/index.md
+++ b/docs/credential-patterns/index.md
@@ -6,18 +6,31 @@ proves that identity. Picking the right one is the single most important
 operational decision in any Entra-integrated app.
 
 This sample is opinionated: **on Azure compute, use Managed Identity.
-For everything else, use Workload Identity Federation. Stop using certs
-and secrets unless you genuinely cannot avoid them.**
+For everything else, use Workload Identity Federation. Avoid certs and
+client secrets unless you genuinely cannot avoid them.** This mirrors
+the dotnet-engineering-guide [ch02 §10 auth-policy doctrine](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz):
+the credential type is part of the policy, not an operational detail.
 
 ## Decision matrix
 
-| Where does your workload run?               | Credential                                                       |
-|---------------------------------------------|-----------------------------------------------------------------:|
-| Azure (App Service, ACA, AKS, Functions, …) | **[Managed Identity](managed-identity.md)**                      |
-| GitHub Actions                              | **[Workload Identity Federation](federated-identity.md)**        |
-| GKE / EKS / on-prem K8s with SPIFFE / OIDC  | **[Workload Identity Federation](federated-identity.md)**        |
-| On-prem service with no IdP / HSM-bound key | [Certificate](cert.md)                                           |
-| Anything else                               | … you almost certainly don't need [client secret](client-secret.md) |
+| Where does your workload run?               | Credential                                                                                                                                             |
+|---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Azure (App Service, ACA, AKS, Functions, …) | **must** use [Managed Identity](managed-identity.md)                                                                                                   |
+| GitHub Actions                              | **must** use [Workload Identity Federation](federated-identity.md)                                                                                     |
+| GKE / EKS / on-prem K8s with SPIFFE / OIDC  | **must** use [Workload Identity Federation](federated-identity.md)                                                                                     |
+| On-prem service with no IdP / HSM-bound key | **should** use [Certificate](cert.md)                                                                                                                  |
+| Anything else                               | you almost certainly don't need a [client secret](client-secret.md) — see that page for the three documented exceptions; **strongly prefer** MI or FIC |
+
+Cross-references:
+
+- The token-acquisition wiring (which library, which `TokenCredential`,
+  caching) lives in [`acquisition.md`](../acquisition.md) §1.
+- The validation side (what the *receiving* API checks on these tokens
+  — `azp` allow-list, `roles`, MI `idtyp`) lives in
+  [`validation.md`](../validation.md) §4 and §5.
+- Per-scenario picker (which credential for which sample service) lives
+  in [`matrix.md`](../matrix.md); the credential rule is owned here per
+  [`coverage-map.md`](../../coverage-map.md).
 
 ## Why this sample stopped using credential menagerie services
 
@@ -35,3 +48,28 @@ admin-consented at the MI's service principal. It is the credential
 pattern any new Azure-resident worker should follow.
 
 The other three patterns survive as 1-page references here.
+
+The rationale for deleting the deployed services (rather than keeping
+them as a "menagerie") is recorded in the commit history of the
+`docs(cred-patterns)` series and in the per-page "Why we used to ship
+this and don't anymore" sections of [`cert.md`](cert.md#why-we-used-to-ship-this-and-dont-anymore)
+and [`client-secret.md`](client-secret.md#why-we-used-to-ship-this-and-dont-anymore).
+The rule the sample now enforces: every deployed service in this repo
+demonstrates a credential pattern that a new Azure workload should
+copy. Patterns that exist only as warnings live in docs, not in
+deployed code.
+
+---
+
+## Sources
+
+- Microsoft Entra credential types — application authentication overview — [learn.microsoft.com/entra/identity-platform/authentication-flows-app-scenarios](https://learn.microsoft.com/entra/identity-platform/authentication-flows-app-scenarios)
+- Managed identities for Azure resources — overview — [learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview)
+- Workload identity federation — [learn.microsoft.com/entra/workload-id/workload-identity-federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+- Certificate credentials on app registrations — [learn.microsoft.com/entra/identity-platform/certificate-credentials](https://learn.microsoft.com/entra/identity-platform/certificate-credentials)
+- OWASP — Secrets Management Cheat Sheet — [cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)
+- OWASP — Cryptographic Storage Cheat Sheet — [cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
+- NIST SP 800-57 Part 1 Rev. 5 — Recommendation for Key Management — [nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf)
+- NIST SP 800-63B — Digital Identity Guidelines (authenticator types) — [pages.nist.gov/800-63-3/sp800-63b.html](https://pages.nist.gov/800-63-3/sp800-63b.html)
+- RFC 8693 — OAuth 2.0 Token Exchange — [rfc-editor.org/rfc/rfc8693](https://www.rfc-editor.org/rfc/rfc8693)
+- dotnet-engineering-guide — ch02 §10 (auth-policy doctrine) — [github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz)

--- a/docs/credential-patterns/managed-identity.md
+++ b/docs/credential-patterns/managed-identity.md
@@ -11,12 +11,26 @@ code or config. Your code asks the IMDS endpoint
 identity to Entra; you get a JWT. No cert, no secret, no rotation.
 
 Two flavors:
-- **System-assigned**: lifecycle bound to the resource (delete the
-  Container App → identity is gone). Simplest. Used by every service
-  in this sample.
-- **User-assigned**: standalone resource you create. Outlives any
+
+- **System-assigned (SAMI)**: lifecycle bound to the resource (delete the
+  Container App → identity is gone). Simplest. One identity per
+  resource — narrowest blast radius. Used by every service in this
+  sample.
+- **User-assigned (UAMI)**: standalone resource you create. Outlives any
   single workload, and one identity can be attached to many resources.
-  Use when you need stable identity across deploys.
+  Use when you need stable identity across deploys, or when several
+  replicas / regional deployments of the *same* workload must share a
+  principal.
+
+**Security implication of UAMI sharing.** Reusing a single UAMI across
+unrelated resources widens the blast radius — a compromise of any one
+host that has the UAMI attached lets the attacker mint tokens with the
+union of every role assignment that UAMI holds. **For high-sensitivity
+workloads, prefer SAMI (one per resource), or a dedicated UAMI per
+workload (not per cluster, not per subscription).** Treat a UAMI like
+you would a service principal: one workload, one identity. See
+[`glossary.md` — Managed Identity (MI)](../../glossary.md#managed-identity-mi--system-assigned-sami-user-assigned-uami)
+for the canonical definitions.
 
 ## Code (worker calling an Entra-protected API)
 
@@ -84,7 +98,33 @@ need a worker app reg. You need:
    ```csharp
    var token = await new ManagedIdentityCredential().GetTokenAsync(
        new TokenRequestContext(["https://graph.microsoft.com/.default"]), ct);
+   // Failure mode: if the MI's SP is missing the Graph app role
+   // (e.g. User.Read.All not granted at step 2 above), the call throws
+   // Azure.Identity.AuthenticationFailedException with an inner
+   // MsalServiceException carrying AADSTS500011 / AADSTS65001-style
+   // "no app role assignment" detail. Fix is at the role-assignment
+   // layer (Graph), not in code.
    ```
+
+## DefaultAzureCredential vs ManagedIdentityCredential
+
+In this sample, **deployed code uses `ManagedIdentityCredential`
+explicitly** (not `DefaultAzureCredential`). Reasons:
+
+- **Predictable failure mode.** `DefaultAzureCredential` walks a chain
+  (env vars → workload identity → MI → VS → Azure CLI → …). On Azure
+  compute the MI step succeeds and the rest is dead weight; in a
+  misconfigured env it can silently fall through to a developer's
+  `az login` cached token, masking a real wiring bug.
+- **Fewer round-trips.** No probing of credential sources that will
+  never be available in production.
+- **Local dev still works.** `run-locally.md` documents using
+  `DefaultAzureCredential` (or `AzureCliCredential`) on a developer
+  machine where there is no MI; production code paths stay explicit.
+
+See [`glossary.md` — DefaultAzureCredential](../../glossary.md#defaultazurecredential)
+and [`acquisition.md` §1a](../acquisition.md#1a-managed-identity--preferred-when-in-azure)
+for the acquisition-side wiring.
 
 ## Why this is the default
 
@@ -97,3 +137,27 @@ need a worker app reg. You need:
 - **Same surface as everything else.** `TokenCredential` is the
   Azure SDK base type — works with Azure Storage, Cosmos DB, Service
   Bus, your own APIs, and Microsoft Graph identically.
+
+## Cross-references
+
+- Acquisition wiring (which library, caching, scope strings) — [`acquisition.md` §1a](../acquisition.md#1a-managed-identity--preferred-when-in-azure).
+- Receiver-side validation of MI tokens (`idtyp`, `azp` allow-list) — [`validation.md` §5](../validation.md#5-mi-tokens).
+- Picker decision (when MI vs FIC vs cert) — [`index.md`](index.md#decision-matrix).
+- Sibling credential patterns — [`federated-identity.md`](federated-identity.md), [`cert.md`](cert.md), [`client-secret.md`](client-secret.md).
+- Local-dev fallback when there is no MI — [`run-locally.md`](../run-locally.md).
+- Auth-policy doctrine (delegated vs app-only, never OR-claims) — dotnet-engineering-guide [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz).
+
+---
+
+## Sources
+
+- Managed identities for Azure resources — overview — [learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview)
+- System-assigned vs user-assigned managed identity — [learn.microsoft.com/entra/identity/managed-identities-azure-resources/managed-identities-faq](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/managed-identities-faq)
+- How to use managed identities with Azure Container Apps — [learn.microsoft.com/azure/container-apps/managed-identity](https://learn.microsoft.com/azure/container-apps/managed-identity)
+- Azure Instance Metadata Service (IMDS) — [learn.microsoft.com/azure/virtual-machines/instance-metadata-service](https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service)
+- How managed identities work with virtual machines (IMDS token endpoint) — [learn.microsoft.com/entra/identity/managed-identities-azure-resources/how-managed-identities-work-vm](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/how-managed-identities-work-vm)
+- `ManagedIdentityCredential` reference — [learn.microsoft.com/dotnet/api/azure.identity.managedidentitycredential](https://learn.microsoft.com/dotnet/api/azure.identity.managedidentitycredential)
+- `DefaultAzureCredential` reference — [learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential)
+- Azure SDK for .NET — Identity client library — [learn.microsoft.com/dotnet/api/overview/azure/identity-readme](https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme)
+- Azure SDK identity guidance — [github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md)
+- Granting Microsoft Graph app roles to a managed identity — [learn.microsoft.com/graph/permissions-grant-via-msgraph-rest-api](https://learn.microsoft.com/graph/permissions-grant-via-msgraph-rest-api)


### PR DESCRIPTION
- index.md: Sources block; reword 'almost certainly don't need client secret' to point at the three documented exceptions in client-secret.md; add cross-refs to acquisition/validation/matrix and ch02 §10; add decision-log section explaining why deployed menagerie services were removed; align decision-matrix table; add must/should/prefer/avoid markers.
- managed-identity.md: Sources block (IMDS, ManagedIdentityCredential, DefaultAzureCredential, Azure SDK identity); spell out UAMI blast-radius implication and prefer SAMI / dedicated UAMI per workload; document Graph failure mode (AuthenticationFailedException when MI lacks app role); add DefaultAzureCredential vs ManagedIdentityCredential rationale; cross-refs to acquisition §1a, validation §5, sibling cred docs.
- federated-identity.md: Sources block (Entra FIC, RFC 8693, OIDC Core, SPIFFE/SVID, GitHub OIDC); explain WHY wildcard subjects are dangerous (collapses branch-protection model — any PR can mint prod tokens); disambiguate SignedAssertionFromManagedIdentity from OIDC-FIC (issuer is tenant STS, not external IdP) and reference glossary.md.
- cert.md: Sources block (OWASP cert mgmt, NIST SP 800-57, FIPS 140-2, PCI DSS); add explicit rotation-cadence section (annual minimum / 90-day best practice / KV auto-renewal); inline EphemeralKeySet comment (in-process memory only, not persisted to disk).
- client-secret.md: Sources block (OWASP secrets mgmt, GitHub secret scanning, Entra audit logs, PCI DSS, RFC 6749 §2.3.1); cite Entra 24-month max with Microsoft Learn link and recommend 6-month rotation; add hybrid runtime guidance (use FIC where possible, cert on-prem fallback, never share a secret across environments); cross-refs to acquisition §1d, validation §4, sibling cred docs.

All five docs: anchored cross-refs to siblings, acquisition.md, validation.md per coverage-map.md; explicit must/should/prefer/avoid strength markers; primary sources only (RFC/IETF/Microsoft Learn/Microsoft GitHub/NIST/OWASP); ch02 §10 auth-policy doctrine cited where invoked.

Pre-flight: anchor-validation script reports 'all anchors ok'; markdownlint clean on docs/credential-patterns/.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
