### PR TITLE
docs(ops): Sources blocks + decisive defaults + cross-refs for lifecycle/ops docs

### DIFF
--- a/docs/aks-shared-infra.md
+++ b/docs/aks-shared-infra.md
@@ -12,6 +12,13 @@ That's a **code/config duplication problem**, not a runtime traffic problem. The
 > **Centralize the *implementation* of auth across all products — not the *runtime path*.**
 > One supported way to do auth in our org, owned by a small platform team, consumed by every product as a library + IaC module. Per-request enforcement stays in each service (zero-trust, no SPOF). The edge handles uniform first-line policy.
 
+## Doctrine — named auth schemes (must)
+
+- Code **MUST** branch on scheme name when an API serves more than one identity provider or audience type.
+- A single `[Authorize]` attribute **MUST NEVER** silently accept multiple issuers, audiences, or token shapes — register each as a distinct named `JwtBearer` scheme and select it per route or per controller.
+- Multiple `AddJwtBearer(...)` calls under the same default scheme name silently *fall through* to the first one that validates. That is a privilege-escalation bug, not a feature. Avoid.
+- Owner: [`validation.md`](validation.md) §3 (multi-tenant + audience) and the .NET auth-policy doctrine in dotnet-engineering-guide [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz). The library wires this for free; teams **MUST NOT** call `AddJwtBearer(...)` directly.
+
 ## What "centralized auth" actually is — four artifacts
 
 ### 1. `EntraAuth.Auth` shared NuGet
@@ -87,7 +94,8 @@ The library approach gives you everything you wanted (one authoritative implemen
 ## Cross-service (east-west) communication
 You said "some cross-service calls." The boring, correct answer:
 - Caller acquires an **app token** (client credentials) for the callee's API, scope `<callee-app-id>/.default`. Use Workload Identity / FIC in AKS — see [acquisition.md](acquisition.md).
-- Callee validates with `[Authorize(Roles = "Grading.Submission.Write")]` **and** `RequireClientApp("<caller-app-id>")` from the library.
+- Callee **MUST** validate **both** `roles` (app-role gate) **AND** `azp` / `appid` (per-client allow-list). Either alone is insufficient: `roles` without `azp` admits any tenant SP that was granted the role; `azp` without `roles` admits any token from that client regardless of permission. Owner: [`validation.md` §4](validation.md#4-app-token-specific-checks) and dotnet-engineering-guide [ch02 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz).
+- In code that means `[Authorize(Roles = "Grading.Submission.Write")]` **and** `RequireClientApp("<caller-app-id>")` from the library — **never one without the other** on an app-only endpoint.
 - That's it. **No mesh required for this.**
 
 A service mesh (Istio/Linkerd) is the right end-state for **mTLS + traffic management**; it is *not* the reason to centralize auth. Defer until the org is ready to operate one.
@@ -100,6 +108,14 @@ A service mesh (Istio/Linkerd) is the right end-state for **mTLS + traffic manag
 5. **Ship `EntraAuth.Auth.Edge`** module; turn it on per product as adoption reaches it.
 6. **Deprecate** in-repo `JwtBearer` boilerplate via a Roslyn analyzer once adoption is high enough.
 7. **Quarterly review** of standards, app-role taxonomy, and tenant allow-list governance.
+
+### Rollback strategy (must)
+
+- Every adopter pins the `EntraAuth.Auth` version in their csproj; no floating `*` versions. A bad library release is rolled back per-service by reverting that pin and redeploying — no platform-team coordination needed.
+- The library follows **semver**: breaking config or behaviour changes go in a major; deprecations ship one major in advance with a Roslyn analyzer warning.
+- Each release is canaried in **one pilot service first**, observed for at least one business cycle on the auth-failure metrics emitted by the library itself, and only then promoted as the recommended version.
+- The edge module (`EntraAuth.Auth.Edge`) is rolled back via the same Bicep/Helm pipeline that deployed it — the previous chart digest is the rollback target. The library re-validates on the pod, so an edge rollback **MUST NOT** loosen what the library still enforces (defense-in-depth holds during rollback).
+- Roslyn analyzer enforcement (step 6) ships as a **warning first, error later** — never both in the same release — so a bad analyzer rule cannot block every product's build at once.
 
 ## Risks & anti-patterns
 - ❌ Building a runtime auth service. Covered above.
@@ -122,3 +138,15 @@ A service mesh (Istio/Linkerd) is the right end-state for **mTLS + traffic manag
 - [validation.md](validation.md) — what the library wires up under the hood.
 - [matrix.md](matrix.md) — per-scenario picks.
 - [best-practices.md](best-practices.md) — rules the library enforces by default.
+
+## Sources
+
+- Microsoft Entra ID best practices — [learn.microsoft.com/entra/identity/fundamentals/identity-best-practices-checklist](https://learn.microsoft.com/entra/identity/fundamentals/identity-best-practices-checklist)
+- Microsoft Entra app roles — [learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps](https://learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps)
+- Microsoft.Identity.Web — multiple authentication schemes — [github.com/AzureAD/microsoft-identity-web/wiki/Multiple-Authentication-Schemes](https://github.com/AzureAD/microsoft-identity-web/wiki/Multiple-Authentication-Schemes)
+- Continuous Access Evaluation (CAE) — [learn.microsoft.com/entra/identity/conditional-access/concept-continuous-access-evaluation](https://learn.microsoft.com/entra/identity/conditional-access/concept-continuous-access-evaluation)
+- Azure Kubernetes Service — workload identity — [learn.microsoft.com/azure/aks/workload-identity-overview](https://learn.microsoft.com/azure/aks/workload-identity-overview)
+- OWASP Zero-Trust Architecture cheat sheet — [cheatsheetseries.owasp.org/cheatsheets/Zero_Trust_Architecture_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/Zero_Trust_Architecture_Cheat_Sheet.html)
+- NIST SP 800-207 Zero Trust Architecture — [nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-207.pdf](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-207.pdf)
+- infra-engineering-guide ch04 (containers/Kubernetes — service mesh "when not to") — [github.com/mghabin/infra-engineering-guide/blob/main/docs/04-containers-k8s.md](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/04-containers-k8s.md)
+- dotnet-engineering-guide ch02 §10 (auth doctrine) — [github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz)

--- a/docs/deploy-cloud.md
+++ b/docs/deploy-cloud.md
@@ -60,7 +60,9 @@ The workflow auto-deploys to dev. Watch progress under **Actions → CD → depl
 
 ## Provisioning per-env Entra app registrations
 
-The CD identity is intentionally scoped to ARM only (no Microsoft Graph). Entra app regs and the resolved env-var wiring are provisioned **out-of-band**, once per env (or whenever app regs change):
+The CD identity is intentionally scoped to ARM only (no Microsoft Graph). Entra app regs and the resolved env-var wiring are provisioned **out-of-band**, once per env (or whenever app regs change).
+
+> **"Out-of-band" means run once per env, not on every push.** The Microsoft Graph application API is rate-limited and is **not designed for per-commit churn** — re-creating app regs, FICs, and admin-consented permission grants on every CI run risks `429 Too Many Requests`, partial failures that leave half-wired tenants, and an audit trail that drowns the real changes. Source-of-truth for the *resulting* wiring is the env-level GitHub variable `ENTRA_CONFIG_JSON`, which CD reads on every push.
 
 ```bash
 ./scripts/provision-apps.sh ENV=dev
@@ -76,7 +78,13 @@ This:
 - Re-deploys `azure.bicep` with a populated `entraConfig` object — env vars now live in the bicep state, no more drift.
 - Publishes the resolved `entraConfig` JSON as the `ENTRA_CONFIG_JSON` env-level GitHub variable, so subsequent CD redeploys pass the same wiring back into bicep.
 
-After this runs once per env, every `git push origin main` fully deploys + wires the env automatically — re-running provision-apps is only needed when the Entra app regs themselves change.
+After this runs once per env, every `git push origin main` fully deploys + wires the env automatically — re-running `provision-apps.sh` is only needed when the Entra app regs themselves change.
+
+### `ENTRA_CONFIG_JSON` source-of-truth and drift
+
+- The **GitHub env variable `vars.ENTRA_CONFIG_JSON` is the source-of-truth** that flows into Bicep on every CD run. CD never reads from Entra directly.
+- `scripts/provision-apps.sh` is the **only** writer: it reconciles app regs in the tenant, then re-publishes the resolved JSON back to the env variable. Anything you change manually in the Entra portal (a redirect URI, an app role, a federated credential) is **drift** until you re-run `provision-apps.sh ENV=<env>`, which re-syncs the variable from the live tenant state.
+- **Never** hand-edit `vars.ENTRA_CONFIG_JSON` in the GitHub UI; the next provision run will overwrite it. If you must change wiring out of sequence, change it in `infra/bicep/main.bicep` (or the relevant `.bicepparam`) and re-run the script.
 
 ## Promoting to ppe and prod
 
@@ -128,3 +136,17 @@ Free-tier ceilings (per Azure subscription):
 
 - [`docs/environments.md`](environments.md) — promotion model, adding a 4th env
 - [`docs/run-locally.md`](run-locally.md) — local-dev path (not cloud)
+- [`docs/operations.md`](operations.md) — on-call runbook (CD UAMI recovery, what-if previews, env teardown)
+
+## Sources
+
+- GitHub Actions OIDC — configuring OpenID Connect in Azure — [docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure](https://docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure)
+- Azure workload identity federation (FIC) — [learn.microsoft.com/entra/workload-id/workload-identity-federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+- Azure RBAC — built-in roles — [learn.microsoft.com/azure/role-based-access-control/built-in-roles](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles)
+- Microsoft Graph throttling guidance (`429`) — [learn.microsoft.com/graph/throttling](https://learn.microsoft.com/graph/throttling)
+- Azure Container Apps — managed identities — [learn.microsoft.com/azure/container-apps/managed-identity](https://learn.microsoft.com/azure/container-apps/managed-identity)
+- SLSA — supply-chain levels for software artifacts — [slsa.dev/spec/v1.0/levels](https://slsa.dev/spec/v1.0/levels)
+- Sigstore / cosign — keyless signing and attestation — [docs.sigstore.dev/cosign/overview](https://docs.sigstore.dev/cosign/overview)
+- GitHub artifact attestations — [docs.github.com/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds](https://docs.github.com/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)
+- infra-engineering-guide ch03 (CI/CD — pinned actions, OIDC over secrets, SLSA/Sigstore) — [github.com/mghabin/infra-engineering-guide/blob/main/docs/03-ci-cd.md](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/03-ci-cd.md)
+- infra-engineering-guide ch06 (security & supply chain — workload identity, no static credentials) — [github.com/mghabin/infra-engineering-guide/blob/main/docs/06-security-supply-chain.md#3-workload-identity--the-no-static-credentials-rule](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/06-security-supply-chain.md#3-workload-identity--the-no-static-credentials-rule)

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -27,6 +27,23 @@ push → build-images (matrix × 7) → tags :sha-XXX, :latest
 - `workflow_dispatch` accepts an `imageTag` input to redeploy a previously-built SHA without rebuilding.
 - `cancel-in-progress: false` on ppe/prod so a follow-up push never interrupts a running deploy.
 
+> **Single-digest implication.** Because the *same* image digest flows
+> dev → ppe → prod, a regression caught in dev **blocks ppe and prod
+> for the same SHA**. There is no "skip dev, ship a hotfix straight to
+> prod" path — by design, prod can only ever run an image that ppe ran
+> and ppe can only ever run one that dev ran. Plan rollbacks
+> accordingly: `gh workflow run cd.yml -f environment=prod -f imageTag=sha-<known-good>`
+> reuses an *older* digest that already passed all three envs; it does
+> **not** re-build. Avoid making "trivial" prod-only doc/config changes
+> in CD config without bumping the SHA — they will not deploy until
+> dev rebuilds.
+
+## Why ppe has no human gate
+
+- **dev → ppe is automatic on dev success; only prod requires a reviewer.** The trade-off is **deliberate**: ppe exists to surface regressions that only appear against production-shaped infra (real ACA cold-start, real LAW ingestion, real Entra app-reg quotas) **before** a human is asked to approve prod. Inserting a human between dev and ppe just means ppe lags dev — and an out-of-date ppe catches **fewer** real issues, not more.
+- **prod is the gate that matters.** A bad SHA reaching ppe is a paged on-call event for the deploy team; a bad SHA reaching prod is a customer-impacting incident. Spending the human-review budget on the *one* hop where the blast radius justifies it is a deliberate **speed-vs-risk** allocation.
+- **Adjust per organisation.** If your org's ppe carries data subject to compliance review (HIPAA, FedRAMP), or is shared with external partners, add a required reviewer on the `ppe` GitHub Environment too — `bootstrap-env.sh` accepts a reviewer list per env. The default in this sample assumes ppe is internal-only.
+
 ## Per-env configuration
 
 What lives where:
@@ -69,3 +86,13 @@ gh api -X DELETE repos/OWNER/REPO/environments/dev
 ```
 
 The federated credential and the user-assigned MI go away with the resource group.
+
+## Sources
+
+- GitHub Actions — using environments for deployment — [docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment](https://docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment)
+- GitHub Actions — environment protection rules (required reviewers, wait timers) — [docs.github.com/actions/deployment/targeting-different-environments/managing-environments-for-deployment#environment-protection-rules](https://docs.github.com/actions/deployment/targeting-different-environments/managing-environments-for-deployment#environment-protection-rules)
+- GitHub Actions — concurrency — [docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs](https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs)
+- Container image digests vs tags (immutable promotion) — [docs.docker.com/reference/cli/docker/image/pull/#pull-an-image-by-digest-immutable-identifier](https://docs.docker.com/reference/cli/docker/image/pull/#pull-an-image-by-digest-immutable-identifier)
+- Progressive delivery patterns — [martinfowler.com/articles/cd-pipeline-patterns.html](https://martinfowler.com/articles/cd-pipeline-patterns.html)
+- Blue/Green deployment (Fowler) — [martinfowler.com/bliki/BlueGreenDeployment.html](https://martinfowler.com/bliki/BlueGreenDeployment.html)
+- infra-engineering-guide ch03 (CI/CD — progressive delivery, blue/green & canary) — [github.com/mghabin/infra-engineering-guide/blob/main/docs/03-ci-cd.md](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/03-ci-cd.md)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -26,10 +26,10 @@ WHAT_IF=1 ENV=dev IMAGE_TAG=preview ./scripts/provision-apps.sh
 
 Behavior:
 
-* **Cold env** (no kitchen container app yet): previews the cold
+- **Cold env** (no kitchen container app yet): previews the cold
   `azure.bicep` deploy and exits. The tenant + wire steps depend on
   ACA-derived values that don't exist yet, so they're skipped.
-* **Warm env**: previews the cold-skip + tenant `main.bicep` deploy
+- **Warm env**: previews the cold-skip + tenant `main.bicep` deploy
   and exits before any side effects (FIC creation, GH variable write,
   wire deploy).
 
@@ -101,7 +101,15 @@ gh workflow run cd.yml \
 ```
 
 Smoke-test polls `/health/live` for up to 180s after the deploy
-completes. If that fails, check the container app revision logs:
+completes. The canonical health-probe contract — three endpoints
+(`/health/live`, `/health/ready`, `/health/startup`), tag-filtered, mapped
+explicitly (NOT via Aspire ServiceDefaults `MapDefaultEndpoints()` which
+only exposes them in Development) — is owned by **dotnet-engineering-guide
+[ch06 §10](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/06-cloud-native.md#10-health-checks--three-endpoints-for-k8s-not-what-servicedefaults-gives-you)**.
+The smoke-test expects HTTP `200` with body `{"status":"Healthy"}` on
+`/health/live`; anything else (including `200` with `Degraded`/`Unhealthy`
+body, or any `5xx`) fails the deploy. If that fails, check the container
+app revision logs:
 
 ```bash
 az containerapp logs show \
@@ -110,35 +118,100 @@ az containerapp logs show \
   --type system --follow
 ```
 
+## CD identity (UAMI) recovery
+
+The per-env CD identity (`ftgo-{env}-cd-mi`) is a user-assigned managed
+identity created by `infra/bicep/bootstrap.bicep` and
+[`scripts/bootstrap-env.sh`](../scripts/bootstrap-env.sh). Its
+`principalId` and `clientId` are stable for the lifetime of the resource
+— but if anyone deletes and re-creates the UAMI (manual portal action,
+RG teardown without `az group delete --no-wait` finishing the FIC
+cleanup, or running bootstrap with a fresh subscription), **both IDs
+change**, and every artefact pinned to the old IDs (the GitHub
+Environment `AZURE_CLIENT_ID`, the federated identity credential subject
+on the UAMI, any `roleAssignments` referencing the principal) becomes
+stale.
+
+Recovery procedure (per env, idempotent):
+
+1. **Rerun bootstrap** for the affected env — it is the only supported
+   creator and is safe to re-run:
+
+   ```bash
+   ./scripts/bootstrap-env.sh ENV=<env>
+   ```
+
+   This re-creates the UAMI if missing, re-asserts the federated identity
+   credential bound to `repo:OWNER/REPO:environment:<env>`, re-applies
+   `Contributor` (and on prod, `User Access Administrator`) on the RG,
+   and re-publishes the new `AZURE_CLIENT_ID` to the GitHub Environment.
+
+2. **Re-publish env wiring** so CD picks up the new identity:
+
+   ```bash
+   ./scripts/provision-apps.sh ENV=<env>
+   ```
+
+   This refreshes `vars.ENTRA_CONFIG_JSON` and re-federates the BFF ACA
+   system MI to its app reg.
+
+3. **Re-run CD** to confirm the new identity can deploy:
+
+   ```bash
+   gh workflow run cd.yml -f environment=<env>
+   ```
+
+If the FIC subject still references the *old* UAMI (visible in the
+"Federated credentials" tab on the Entra app reg) AAD will reject the
+new OIDC exchange with `AADSTS70021: No matching federated identity
+record found`. The bootstrap script removes orphan FICs on re-run; if
+the workflow still fails with that code, check that
+`bootstrap.bicep` ran to completion — the comment block at the top of
+`infra/bicep/cd-bootstrap.bicep` documents the exact assertion order.
+
 ## Provisioning a brand-new env
 
 1. Create the matching GitHub Environment (`dev`/`ppe`/`prod`) with
    the standard env vars/secrets (`AZURE_CLIENT_ID`,
    `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`).
 2. Create the federated credential on the bootstrap app reg for that
-   environment (one-time, see `infra/bicep/bootstrap.bicep`).
+   environment (one-time, see [`infra/bicep/bootstrap.bicep`](../infra/bicep/bootstrap.bicep)
+   and the wrapper [`scripts/bootstrap-env.sh`](../scripts/bootstrap-env.sh)).
 3. Run `provision-apps.sh ENV=<env> IMAGE_TAG=<tag>`.
 4. The script writes `vars.ENTRA_CONFIG_JSON` for the env so future CD
    runs are fully declarative.
 
 ## When something is on fire
 
-* **`/scalar/v1` returns AADSTS900021** — `vars.ENTRA_CONFIG_JSON` is
+- **`/scalar/v1` returns AADSTS900021** — `vars.ENTRA_CONFIG_JSON` is
   empty for that env. Re-run `provision-apps.sh ENV=<env>` to populate.
-* **CD smoke-test fails after a successful deploy** — check container
+- **CD smoke-test fails after a successful deploy** — check container
   app logs (above); 180s should be enough for cold-start, but image
   pull from a new registry can be slower.
-* **Ruleset drift alert** — open `.github/rulesets/main.json`,
+- **Ruleset drift alert** — open `.github/rulesets/main.json`,
   reconcile against the failure diff in the workflow log, commit a fix,
   then apply manually using the `gh api` snippet in the
   "Branch protection (Repository Rulesets)" section above.
-* **CD `build-images` fails with Trivy CRITICAL/HIGH** — open the SARIF
+- **CD `build-images` fails with Trivy CRITICAL/HIGH** — open the SARIF
   upload in the Security tab to see the CVE list. Fix order:
   bump the base image (Dockerfile FROM tag) and let Dependabot's
   docker ecosystem PR land, OR rebuild after upstream pushes a fix.
   Unfixable CVEs are already filtered (`ignore-unfixed: true`); a
   failure means there *is* a fix available somewhere in the dep tree.
-* **CD aborts with "Refusing to deploy unattested images"** — image was
+- **CD aborts with "Refusing to deploy unattested images"** — image was
   pushed before the SLSA provenance pipeline was added, or the
   attestation got pruned. Re-run `cd.yml`'s `build-images` job to
   rebuild and re-attest.
+
+## Sources
+
+- Azure CLI command reference — [learn.microsoft.com/cli/azure/reference-index](https://learn.microsoft.com/cli/azure/reference-index)
+- `az containerapp logs show` — [learn.microsoft.com/cli/azure/containerapp/logs#az-containerapp-logs-show](https://learn.microsoft.com/cli/azure/containerapp/logs#az-containerapp-logs-show)
+- Bicep `what-if` — preview deployments — [learn.microsoft.com/azure/azure-resource-manager/bicep/deploy-what-if](https://learn.microsoft.com/azure/azure-resource-manager/bicep/deploy-what-if)
+- Resource Manager locks (`CanNotDelete`) — [learn.microsoft.com/azure/azure-resource-manager/management/lock-resources](https://learn.microsoft.com/azure/azure-resource-manager/management/lock-resources)
+- Azure Key Vault soft-delete and purge protection — [learn.microsoft.com/azure/key-vault/general/soft-delete-overview](https://learn.microsoft.com/azure/key-vault/general/soft-delete-overview)
+- GitHub Actions — viewing workflow run logs — [docs.github.com/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs)
+- GitHub Repository Rulesets API — [docs.github.com/rest/repos/rules](https://docs.github.com/rest/repos/rules)
+- Workload identity federation — error reference (`AADSTS70021` etc.) — [learn.microsoft.com/entra/identity-platform/reference-error-codes](https://learn.microsoft.com/entra/identity-platform/reference-error-codes)
+- dotnet-engineering-guide ch06 §10 (canonical `/health/{live,ready,startup}` contract) — [github.com/mghabin/dotnet-engineering-guide/blob/main/docs/06-cloud-native.md#10-health-checks--three-endpoints-for-k8s-not-what-servicedefaults-gives-you](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/06-cloud-native.md#10-health-checks--three-endpoints-for-k8s-not-what-servicedefaults-gives-you)
+- infra-engineering-guide ch05 (observability — SLO-driven alerting, structured logging) — [github.com/mghabin/infra-engineering-guide/blob/main/docs/05-observability.md](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/05-observability.md)

--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -46,6 +46,22 @@ allowed callers on `ftgo-dev-orders-api` and `ftgo-dev-restaurants-api`.
 > they only accept tokens from the real workload identities (BFF + workers).
 > Laptop-issued tokens are by design a dev-env affordance.
 
+> **Why Azure CLI is treated as a public client.** Azure CLI (and VS
+> Code) are **public clients** — they ship to every developer machine
+> and **cannot hold a secret** (anything compiled in or stored on disk
+> would be world-readable on enterprise-managed laptops). Per OAuth 2.1
+> and the OIDC Core spec, public clients authenticate the *user*, not
+> the client itself, using **PKCE** ([RFC 7636](https://www.rfc-editor.org/rfc/rfc7636))
+> instead of a client secret. That is the right model for a CLI on a
+> trusted developer workstation; it is the **wrong** model for a cloud
+> workload, which has a stable identity and **MUST** use Managed
+> Identity / FIC ([`credential-patterns/managed-identity.md`](credential-patterns/managed-identity.md),
+> [`credential-patterns/federated-identity.md`](credential-patterns/federated-identity.md)).
+> Whitelisting the Azure CLI app id (`04b07795-…`) on a resource
+> therefore **MUST** stay scoped to dev — promoting it to prod would
+> mean accepting tokens from any signed-in developer's laptop as if
+> they were the workload itself. Avoid.
+
 Acquire a user token and call the API:
 
 ```bash
@@ -69,6 +85,12 @@ https://ftgo-dev-apigateway-eus.<random>.eastus.azurecontainerapps.io/scalar/v1
 
 ## 5. Telemetry — Aspire Dashboard locally (optional)
 
+The Aspire Dashboard via docker-compose is **optional** and exists only
+for local debugging — to inspect OTLP traces/metrics/logs without
+shipping them to the cloud App Insights workspace. Skip this section
+entirely if you don't need local telemetry; nothing else in the sample
+depends on it.
+
 ```bash
 docker compose -f tests/local/docker-compose.yml up -d
 open http://localhost:18888
@@ -88,3 +110,14 @@ service locally that you wish to export traces from.
 
 The MI demo runs on every cloud deploy. The FIC demo runs on its own
 schedule via `wi-demo.yml`. Both are production-grade.
+
+## Sources
+
+- Sign in with Azure CLI — `az login` — [learn.microsoft.com/cli/azure/authenticate-azure-cli](https://learn.microsoft.com/cli/azure/authenticate-azure-cli)
+- `az account get-access-token` — [learn.microsoft.com/cli/azure/account#az-account-get-access-token](https://learn.microsoft.com/cli/azure/account#az-account-get-access-token)
+- `DefaultAzureCredential` — credential chain order — [learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential)
+- Azure.Identity authentication for .NET apps — [learn.microsoft.com/dotnet/azure/sdk/authentication/](https://learn.microsoft.com/dotnet/azure/sdk/authentication/)
+- Microsoft identity platform — public vs confidential client applications — [learn.microsoft.com/entra/identity-platform/msal-client-applications](https://learn.microsoft.com/entra/identity-platform/msal-client-applications)
+- RFC 7636 — Proof Key for Code Exchange (PKCE) — [rfc-editor.org/rfc/rfc7636](https://www.rfc-editor.org/rfc/rfc7636)
+- OpenID Connect Core 1.0 — [openid.net/specs/openid-connect-core-1_0.html](https://openid.net/specs/openid-connect-core-1_0.html)
+- .NET Aspire dashboard — [learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/overview](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/overview)

--- a/docs/sample-setup.md
+++ b/docs/sample-setup.md
@@ -26,12 +26,12 @@ Create three app registrations per env. Provisioning is declarative via the **Mi
 
 1. **ftgo-dev-bff** (single-tenant) — OIDC web client + OBO. Uses `SignedAssertionFromManagedIdentity` so it has **no stored secret/cert**. Consumes `orders.read` delegated scope.
 2. **ftgo-dev-orders-api** (single-tenant) — exposes scope `orders.read` and app role `Orders.Process`.
-3. **ftgo-dev-restaurants-api** (multi-tenant, `signInAudience: AzureADMultipleOrgs`) — exposes app role `Restaurants.Read.All`.
+3. **ftgo-dev-restaurants-api** (multi-tenant, `signInAudience: AzureADMultipleOrgs`) — exposes app role `Restaurants.Read.All`. **Why multi-tenant here** while `ftgo-dev-orders-api` stays single-tenant: the sample deliberately demonstrates *both* validation shapes side by side. Restaurants is the canonical multi-tenant SaaS resource — it forces the `AadIssuerValidator` + `tid` allow-list pattern owned by [`validation.md` §3](./validation.md#3-issuer-audience-v1-vs-v2-single-vs-multi-tenant). Orders stays single-tenant so the simpler issuer-pinned default ([`validation.md` §3 — Single-tenant](./validation.md#single-tenant)) and the `azp` allow-list ([`validation.md` §4](./validation.md#4-app-token-specific-checks)) read cleanly without multi-tenant noise. The architectural rationale lives in those sections; this page only declares which app reg demonstrates which.
 
 `Ftgo.Kitchen.Worker` has **no app registration** — it authenticates as its system-assigned Container App MI, which is granted `Orders.Process` directly via `permission-grants.bicep`.
 
 For each API app reg, set manifest `requestedAccessTokenVersion = 2` so
-`aud` is the API's client ID GUID.
+`aud` is the API's client ID GUID. v1 vs v2 trade-offs and the rules for accepting both during migration are owned by [`validation.md` §3 — Token versions](./validation.md#token-versions); **prefer v2** for all new apps.
 
 ## Permissions / role grants
 
@@ -99,3 +99,13 @@ dotnet run --project src/Ftgo.Kitchen.Worker
 - No local fake / TestKit (per scope decision — see `run-locally.md` for the free real-tenant path).
 - No SPA / mobile client. Bring a user token (e.g. Postman + auth-code+PKCE against the BFF app reg).
 - No deployed cert / secret / non-MI-FIC workers — those patterns live in [`docs/credential-patterns/`](./credential-patterns/) for reference only.
+
+## Sources
+
+- Microsoft Entra app roles — [learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps](https://learn.microsoft.com/entra/identity-platform/howto-add-app-roles-in-apps)
+- Microsoft.Identity.Web — protected web API audience validation — [github.com/AzureAD/microsoft-identity-web/wiki/web-apis](https://github.com/AzureAD/microsoft-identity-web/wiki/web-apis)
+- Access token claims reference (`aud`, `azp`, `roles`, `scp`, `tid`) — [learn.microsoft.com/entra/identity-platform/access-token-claims-reference](https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference)
+- Application manifest `requestedAccessTokenVersion` — [learn.microsoft.com/entra/identity-platform/reference-app-manifest#requestedaccesstokenversion-attribute](https://learn.microsoft.com/entra/identity-platform/reference-app-manifest#requestedaccesstokenversion-attribute)
+- Multi-tenant apps — `signInAudience` and tenant validation — [learn.microsoft.com/entra/identity-platform/howto-convert-app-to-be-multi-tenant](https://learn.microsoft.com/entra/identity-platform/howto-convert-app-to-be-multi-tenant)
+- App-registration naming and least-privilege guidance — [learn.microsoft.com/entra/identity-platform/security-best-practices-for-app-registration](https://learn.microsoft.com/entra/identity-platform/security-best-practices-for-app-registration)
+- dotnet-engineering-guide ch02 §10 (auth doctrine — `scp` vs `roles` vs `azp`) — [github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz)


### PR DESCRIPTION
Aligns ops/lifecycle docs with dotnet-engineering-guide and infra-engineering-guide doctrine.

## Files
- docs/aks-shared-infra.md
- docs/deploy-cloud.md
- docs/environments.md
- docs/operations.md
- docs/run-locally.md
- docs/sample-setup.md

## Changes
- Sources blocks with primary citations.
- Decisive defaults with explicit fallback.
- Anchored cross-refs to siblings, acquisition.md, validation.md per coverage-map.md.
- must/should/prefer/avoid strength markers.

## Pre-flight
- markdownlint clean.