### PR TITLE
docs: DOCTRINE.md + copilot-instructions.md (search-order contract for upstream guides)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,52 @@
+# Copilot / AI agent instructions for `mghabin/entra-auth-patterns-dotnet`
+
+> **Read this file before generating code or docs in this repo.** It is the entry point for any AI agent (GitHub Copilot, Claude, Cursor, etc.) working here.
+
+## What this repo is
+
+A **reference implementation** of Microsoft Entra ID auth patterns in .NET. It is **not** a doctrine source. Every architectural rule it follows traces back to one of two upstream guides.
+
+## Search order (mandatory)
+
+When asked to add or change behavior, follow this order **before** writing code:
+
+1. **[`DOCTRINE.md`](../DOCTRINE.md)** — the table that maps each topic to its upstream owner. Start here.
+2. **[`coverage-map.md`](../coverage-map.md)** — which file in `docs/` already owns the concept, if it lives in this repo.
+3. **[`mghabin/dotnet-engineering-guide`](https://github.com/mghabin/dotnet-engineering-guide)** — language, ASP.NET Core, testing, performance, cloud-native, client. Especially [`docs/02-aspnetcore.md` §10 Authn/Authz](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz) for auth.
+4. **[`mghabin/infra-engineering-guide`](https://github.com/mghabin/infra-engineering-guide)** — IaC, CI/CD, containers, observability, security supply-chain, networking, data, reliability, FinOps, platform, identity.
+5. **[`docs/`](../docs/)** in this repo — the entra-specific specializations.
+6. **Primary sources** — RFC / Microsoft Learn / NIST / OWASP. **Not** Medium / random blog posts.
+
+If steps 1-5 cover the topic, **do not invent new doctrine**. Cite the upstream owner with an anchored link and apply the existing rule. If you must extend doctrine, the new rule belongs in the **upstream guide**, not in this repo.
+
+## Hard rules (non-negotiable)
+
+- **Auth doctrine** is dotnet-guide ch02 §10. Never combine `scp` and `roles` in a single policy. The repo's named policies are `OrdersAuthorizationPolicies.Delegated` (rejects tokens with `roles`) and `.App` (rejects tokens with `scp`). Do not introduce a third "either / or" policy.
+- **Deny-by-default** authorization. Endpoints opt out of auth with explicit `[AllowAnonymous]`, never the reverse.
+- **JWT defaults** are explicit: `MapInboundClaims = false`, `ValidateIssuer = true`, `ValidateAudience = true`, `ValidateLifetime = true`, `ValidateIssuerSigningKey = true`, `RequireSignedTokens = true`, `RequireExpirationTime = true`. Do not relax these.
+- **Multi-tenant** validation uses `AadIssuerValidator` + a `tid` allow-list, never a hand-rolled regex.
+- **Credential picker**: MI on Azure compute → FIC across OIDC issuers → cert as portable fallback → client secret only for the three documented exceptions in [`docs/credential-patterns/client-secret.md`](../docs/credential-patterns/client-secret.md).
+- **`SignedAssertionFromManagedIdentity`** is **not** OIDC-FIC. Do not conflate them. Issuer is the tenant STS, not an external IdP. See [`glossary.md`](../glossary.md).
+- **FIC subjects** are pinned to a single repo + ref (e.g. `repo:mghabin/entra-auth-patterns-dotnet:ref:refs/heads/main` or a specific environment). Never wildcard.
+- **CI/CD doctrine** is infra-guide ch03/ch06. All third-party Actions pinned to commit SHA. All workflows pass markdownlint, actionlint, lychee, gitleaks, dependency-review, CodeQL, Scorecard, pinact.
+- **Idle cost** is $0. ACA `minReplicas=0` for everything. No premium SKUs. Log Analytics has a daily cap. Teardown via `azd down` or `az group delete` is documented and clean.
+- **Markdown** follows `.markdownlint.yaml`: ordered lists restart per section (MD029); no heading skips (MD001); `-` bullets only (MD004). Every doc has a `## Sources` block with primary citations.
+
+## Workflow expectations
+
+- Branch off `main`, push, open PR, watch checks, squash-merge with admin if and only if all checks pass. Never bypass without admin.
+- Add/extend tests in `tests/` for any auth- or policy-affecting code change. The bar is the existing 51 passing tests.
+- For docs: anchored cross-refs only. Update [`coverage-map.md`](../coverage-map.md) if a concept moves owners. Update [`glossary.md`](../glossary.md) if a new normative term appears.
+- For infra: any new resource must declare `dependsOn` explicitly when ordering matters. Comment FIC idempotency hazards. No empty `appClientId` on warm re-runs.
+
+## Co-authorship
+
+Commits authored by an AI agent must include the trailer:
+
+```
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```
+
+## When in doubt
+
+Stop. Ask. Or: read [`DOCTRINE.md`](../DOCTRINE.md) again and pick the upstream owner.

--- a/DOCTRINE.md
+++ b/DOCTRINE.md
@@ -1,0 +1,70 @@
+# DOCTRINE — where canonical guidance lives
+
+This repo is a **reference implementation**, not a doctrine source.
+Every architectural rule it follows traces back to one of two upstream guides:
+
+- [`mghabin/dotnet-engineering-guide`](https://github.com/mghabin/dotnet-engineering-guide) — language, framework, ASP.NET Core, testing, performance, cloud-native, client.
+- [`mghabin/infra-engineering-guide`](https://github.com/mghabin/infra-engineering-guide) — IaC, CI/CD, containers/K8s, observability, security supply-chain, networking, data, reliability, FinOps, platform engineering, identity.
+
+If a question is not answered by the table below or by [`coverage-map.md`](./coverage-map.md), **search those two repos first**, then [`docs/`](./docs/), then primary sources (RFC / Microsoft Learn / NIST / OWASP). Only after all four have been searched should new doctrine be authored — and new doctrine **belongs in the upstream guide it logically extends**, not here.
+
+---
+
+## How to use this map
+
+- **Humans**: scan the relevant row, follow the link, read the chapter section, then return here for the entra-specific specialization.
+- **AI agents working in this repo**: `.github/copilot-instructions.md` repeats this rule with a search-order contract. Honor it before generating code or docs.
+
+The rule is one-way: this repo **cites** the upstream guides; the upstream guides do **not** cite this repo (this is a sample, not a source of truth).
+
+---
+
+## Doctrine reference table
+
+| Topic in this repo | Upstream owner | Section / chapter |
+| --- | --- | --- |
+| ASP.NET Core auth (`scp` vs `roles`+`azp` named policies, JWT defaults, multi-tenant `IssuerValidator`, `tid` allow-list, deny-by-default) | dotnet-engineering-guide | [`docs/02-aspnetcore.md` §10 Authn/Authz](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md#10-authnauthz) |
+| HTTP pipeline order, problem-details, model binding, minimal APIs vs MVC | dotnet-engineering-guide | [`docs/02-aspnetcore.md`](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md) |
+| HttpClient + Polly resilience pipeline, named clients, timeouts | dotnet-engineering-guide | [`docs/02-aspnetcore.md`](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/02-aspnetcore.md), [`docs/05-performance.md`](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/05-performance.md) |
+| Testing strategy (unit / integration / WebApplicationFactory / Testcontainers / contract) | dotnet-engineering-guide | [`docs/04-testing.md`](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/04-testing.md) |
+| Allocation, async, perf hot-paths | dotnet-engineering-guide | [`docs/05-performance.md`](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/05-performance.md) |
+| Cloud-native runtime (containers, health, config, secrets at runtime) | dotnet-engineering-guide | [`docs/06-cloud-native.md`](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/06-cloud-native.md) |
+| C# language features, project layout, nullable, analyzers | dotnet-engineering-guide | [`docs/01-foundations.md`](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/01-foundations.md) |
+| EF Core, Dapper, transactions, outbox | dotnet-engineering-guide | [`docs/03-data.md`](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/03-data.md) |
+| Decision trees a senior .NET architect actually faces | dotnet-engineering-guide | [`docs/decision-trees.md`](https://github.com/mghabin/dotnet-engineering-guide/blob/main/docs/decision-trees.md) |
+| IaC tooling decision (Bicep vs Terraform vs Pulumi), module shape | infra-engineering-guide | [`docs/02-iac-tooling.md`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/02-iac-tooling.md) |
+| CI/CD pipelines, image promotion by SHA, environments, gates | infra-engineering-guide | [`docs/03-ci-cd.md`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/03-ci-cd.md) |
+| Container build (chiseled / distroless / non-root), Kubernetes / ACA defaults | infra-engineering-guide | [`docs/04-containers-k8s.md`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/04-containers-k8s.md) |
+| Observability (OpenTelemetry → Azure Monitor / Loki / Tempo), SLOs | infra-engineering-guide | [`docs/05-observability.md`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/05-observability.md) |
+| Security supply-chain (SLSA, pinact, OpenSSF Scorecard, Dependabot, gitleaks, dependency-review, CodeQL) | infra-engineering-guide | [`docs/06-security-supply-chain.md`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/06-security-supply-chain.md) |
+| Networking (private endpoints, egress, VNet, WAF, mTLS) | infra-engineering-guide | [`docs/07-networking.md`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/07-networking.md) |
+| Data-state (managed DB defaults, backup, residency) | infra-engineering-guide | [`docs/08-data-state.md`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/08-data-state.md) |
+| Reliability (SLI / SLO / error budget, retry / timeout / circuit, blast-radius) | infra-engineering-guide | [`docs/09-reliability.md`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/09-reliability.md) |
+| FinOps (idle cost, scale-to-zero, ACR Basic, daily caps, teardown) | infra-engineering-guide | [`docs/10-finops.md`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/10-finops.md) |
+| Platform engineering (golden paths, paved roads, multi-tenant compute) | infra-engineering-guide | [`docs/11-platform-engineering.md`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/11-platform-engineering.md) |
+| Workload identity (Entra workload-id, FIC, MI, OIDC issuer, SPIFFE) — *infra-side* | infra-engineering-guide | [`docs/12-identity.md`](https://github.com/mghabin/infra-engineering-guide/blob/main/docs/12-identity.md) |
+| Entra app-side patterns: token acquisition, validation, credential picker, sample registrations | **this repo** | [`docs/`](./docs/) + [`coverage-map.md`](./coverage-map.md) |
+
+---
+
+## What lives in *this* repo (and nowhere else)
+
+This is the **only** layer you should not look upstream for:
+
+- The wiring of [`Microsoft.Identity.Web`](https://learn.microsoft.com/entra/identity-platform/microsoft-identity-web) into a multi-service ASP.NET Core sample.
+- The `OrdersDelegated` / `OrdersApp` named-policy split that operationalizes dotnet-guide ch02 §10.
+- The BFF-style `SignedAssertionFromManagedIdentity` pattern (clarified as **not** OIDC-FIC) and its disambiguation.
+- The credential-picker for *Entra app-credentials* (MI / FIC / cert / secret) including the three documented exceptions for client secret.
+- The per-environment app-registration and FIC creation Bicep modules, parameterized for dev / ppe / prod.
+- The end-to-end runnable FTGO demo (ApiGateway, Auth, Auth.Client, Orders.Api, Restaurants.Api, Kitchen.Worker) that exercises all of the above on Azure Container Apps.
+
+Everything else — language, framework, IaC, CI/CD, observability, FinOps, supply-chain — defers upstream. If a doctrine claim in this repo cannot be traced to a row in the table above or a primary source cited in the relevant doc's `## Sources` block, treat it as a bug and open an issue.
+
+---
+
+## Sources
+
+- Microsoft.Identity.Web — [learn.microsoft.com/entra/identity-platform/microsoft-identity-web](https://learn.microsoft.com/entra/identity-platform/microsoft-identity-web)
+- Microsoft identity platform overview — [learn.microsoft.com/entra/identity-platform/v2-overview](https://learn.microsoft.com/entra/identity-platform/v2-overview)
+- dotnet-engineering-guide — [github.com/mghabin/dotnet-engineering-guide](https://github.com/mghabin/dotnet-engineering-guide)
+- infra-engineering-guide — [github.com/mghabin/infra-engineering-guide](https://github.com/mghabin/infra-engineering-guide)

--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@
 
 ## Read this first
 
-Before diving into the chapters, the four cross-cutting synthesis pages tell you whether this guide fits, what it covers, what every term means, and which decision lives where:
+Before diving into the chapters, the five cross-cutting synthesis pages tell you whether this guide fits, where canonical guidance lives, what it covers, what every term means, and which decision lives where:
 
+- [`DOCTRINE.md`](DOCTRINE.md) — **read first.** This repo defers to [`mghabin/dotnet-engineering-guide`](https://github.com/mghabin/dotnet-engineering-guide) and [`mghabin/infra-engineering-guide`](https://github.com/mghabin/infra-engineering-guide) for everything that is not an Entra-specific specialization. The doctrine table tells you which upstream chapter owns which topic.
 - [`SCOPE.md`](SCOPE.md) — who this guide is for, who it isn't, and the explicit non-goals.
 - [`docs/decision-trees.md`](docs/decision-trees.md) — five Mermaid trees for the highest-leverage Entra decisions; entry point for the reading path.
 - [`coverage-map.md`](coverage-map.md) — exact ownership map: which doc owns which doctrine; siblings link, never re-decide.
 - [`glossary.md`](glossary.md) — every normatively-used term with a primary-source link.
+
+> **For AI agents:** see [`.github/copilot-instructions.md`](.github/copilot-instructions.md). The search-order contract is mandatory.
 
 A working reference for **acquiring** and **validating** Microsoft Entra ID
 tokens in .NET 10 server-side apps. Covers app tokens (S2S / daemon) and


### PR DESCRIPTION
Establishes that this repo is a **reference implementation** that defers to mghabin/dotnet-engineering-guide and mghabin/infra-engineering-guide as upstream doctrine sources. Every topic that is not an Entra-specific specialization now has an explicit upstream owner.

## Files
- DOCTRINE.md (new) — topic → upstream owner table.
- .github/copilot-instructions.md (new) — mandatory search-order contract for AI agents.
- README.md — 'Read this first' leads with DOCTRINE.md.

## Why
Future agents (Copilot CLI, Cursor, etc.) and humans alike now have a single 'where does this rule live' lookup, and a clear rule: cite upstream — don't re-derive. New doctrine belongs in the upstream guide it logically extends, not here.