### PR TITLE
feat(auth): security headers + per-tenant rate limiter + forwarded headers + JSON health probes (prod-readiness wave)

### DIFF
--- a/src/Ftgo.ApiGateway/Program.cs
+++ b/src/Ftgo.ApiGateway/Program.cs
@@ -18,12 +18,21 @@ builder.Services.AddHealthChecks();
 
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddControllers();
+builder.Services.AddEntraAuthRateLimiter();
+builder.Services.AddEntraAuthForwardedHeaders();
 
 var app = builder.Build();
+app.UseForwardedHeaders();
+app.UseEntraAuthSecurityHeaders(new EntraAuthSecurityHeaderOptions
+{
+    // BFF serves the Scalar HTML UI; loosen CSP enough for it to render but keep frame-ancestors locked.
+    ContentSecurityPolicy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'",
+});
 app.UseEntraAuthProblemDetails();
 app.UseAuthentication();
 app.UseAuthorization();
-app.MapControllers();
+app.UseRateLimiter();
+app.MapControllers().RequireRateLimiting(EntraAuthRateLimiterExtensions.DefaultPolicyName);
 app.MapEntraAuthScalar(builder.Configuration, "orders.read");
 app.MapEntraAuthHealthChecks();
 await app.RunAsync();

--- a/src/Ftgo.Auth/EntraAuthForwardedHeadersExtensions.cs
+++ b/src/Ftgo.Auth/EntraAuthForwardedHeadersExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ftgo.Auth;
+
+/// <summary>Adds proxy-aware request handling so <see cref="Microsoft.AspNetCore.Http.HttpRequest.Scheme"/>,
+/// <see cref="Microsoft.AspNetCore.Http.ConnectionInfo.RemoteIpAddress"/>, and <c>Host</c> reflect the
+/// caller's view, not the proxy's. Required behind Azure Container Apps / Front Door / App Gateway / NGINX,
+/// per the ASP.NET Core
+/// <see href="https://learn.microsoft.com/aspnet/core/host-and-deploy/proxy-load-balancer">forwarded-headers
+/// guidance</see> and RFC 7239.</summary>
+public static class EntraAuthForwardedHeadersExtensions
+{
+    /// <summary>Configures <see cref="ForwardedHeadersOptions"/> to honour <c>X-Forwarded-For</c>,
+    /// <c>X-Forwarded-Proto</c>, and <c>X-Forwarded-Host</c>. Default trusted-network list is empty —
+    /// callers should add the proxy's IP/CIDR via <see cref="ForwardedHeadersOptions.KnownProxies"/>
+    /// or <see cref="ForwardedHeadersOptions.KnownNetworks"/> in production. Container Apps' built-in
+    /// envoy proxy is implicitly trusted via the loopback default.</summary>
+    public static IServiceCollection AddEntraAuthForwardedHeaders(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.Configure<ForwardedHeadersOptions>(o =>
+        {
+            o.ForwardedHeaders = ForwardedHeaders.XForwardedFor
+                                 | ForwardedHeaders.XForwardedProto
+                                 | ForwardedHeaders.XForwardedHost;
+            // Tighten in prod via KnownProxies/KnownNetworks; loopback (the platform sidecar) is implicit.
+            o.ForwardLimit = 2;
+        });
+        return services;
+    }
+}

--- a/src/Ftgo.Auth/EntraAuthRateLimiterExtensions.cs
+++ b/src/Ftgo.Auth/EntraAuthRateLimiterExtensions.cs
@@ -1,10 +1,10 @@
 using System.Globalization;
+using System.Security.Claims;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.DependencyInjection;
-using System.Security.Claims;
 
 namespace Ftgo.Auth;
 

--- a/src/Ftgo.Auth/EntraAuthRateLimiterExtensions.cs
+++ b/src/Ftgo.Auth/EntraAuthRateLimiterExtensions.cs
@@ -1,0 +1,109 @@
+using System.Globalization;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
+using System.Security.Claims;
+
+namespace Ftgo.Auth;
+
+/// <summary>Per-caller rate limiter using ASP.NET Core's built-in
+/// <see href="https://learn.microsoft.com/aspnet/core/performance/rate-limit"><c>System.Threading.RateLimiting</c></see>.
+/// Doctrine: every public API enforces a default ceiling so a single misbehaving caller (legit or compromised)
+/// can't exhaust capacity. Per-tenant + per-user partitioning keeps tenants isolated; unauthenticated requests
+/// are bucketed by remote IP.</summary>
+/// <remarks>
+/// <para>Default policy <see cref="DefaultPolicyName"/> is a sliding-window limiter:</para>
+/// <list type="bullet">
+///   <item>Authenticated: partition by <c>tid|oid</c> (Entra tenant + object id).</item>
+///   <item>Unauthenticated: partition by <c>ip|&lt;remote-ip&gt;</c>.</item>
+///   <item>100 requests per 60 seconds per partition; 429 with <c>Retry-After</c> on rejection.</item>
+/// </list>
+/// <para>Tune via <see cref="EntraAuthRateLimiterOptions"/>. Cite RFC 6585 §4 for the 429 status semantics.</para>
+/// </remarks>
+public static class EntraAuthRateLimiterExtensions
+{
+    public const string DefaultPolicyName = "EntraAuthDefault";
+
+    /// <summary>Registers the rate-limiter services and the <see cref="DefaultPolicyName"/> policy.</summary>
+    public static IServiceCollection AddEntraAuthRateLimiter(
+        this IServiceCollection services,
+        Action<EntraAuthRateLimiterOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        var opts = new EntraAuthRateLimiterOptions();
+        configure?.Invoke(opts);
+
+        services.AddRateLimiter(rl =>
+        {
+            rl.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+            rl.OnRejected = static (ctx, _) =>
+            {
+                if (ctx.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+                {
+                    ctx.HttpContext.Response.Headers.RetryAfter =
+                        ((int)retryAfter.TotalSeconds).ToString(CultureInfo.InvariantCulture);
+                }
+                return ValueTask.CompletedTask;
+            };
+
+            rl.AddPolicy(DefaultPolicyName, ctx => RateLimitPartition.GetSlidingWindowLimiter(
+                partitionKey: PartitionKey(ctx),
+                factory: _ => new SlidingWindowRateLimiterOptions
+                {
+                    PermitLimit = opts.PermitLimit,
+                    Window = opts.Window,
+                    SegmentsPerWindow = opts.SegmentsPerWindow,
+                    QueueLimit = 0,
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    AutoReplenishment = true,
+                }));
+
+            rl.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(ctx =>
+                RateLimitPartition.GetSlidingWindowLimiter(
+                    partitionKey: PartitionKey(ctx),
+                    factory: _ => new SlidingWindowRateLimiterOptions
+                    {
+                        PermitLimit = opts.PermitLimit,
+                        Window = opts.Window,
+                        SegmentsPerWindow = opts.SegmentsPerWindow,
+                        QueueLimit = 0,
+                        AutoReplenishment = true,
+                    }));
+        });
+
+        return services;
+    }
+
+    internal static string PartitionKey(HttpContext ctx)
+    {
+        var user = ctx.User;
+        if (user.Identity?.IsAuthenticated == true)
+        {
+            // Per Microsoft Entra access-token-claims-reference, `tid` and `oid` are the stable per-tenant
+            // and per-principal identifiers. With MapInboundClaims=false they appear under the short names.
+            // https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference
+            var tid = user.FindFirstValue("tid")
+                       ?? user.FindFirstValue("http://schemas.microsoft.com/identity/claims/tenantid")
+                       ?? "unknown-tid";
+            var oid = user.FindFirstValue("oid")
+                       ?? user.FindFirstValue("http://schemas.microsoft.com/identity/claims/objectidentifier")
+                       ?? user.FindFirstValue("sub")
+                       ?? "unknown-oid";
+            return $"u|{tid}|{oid}";
+        }
+        var ip = ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown-ip";
+        return $"ip|{ip}";
+    }
+}
+
+/// <summary>Knobs for <see cref="EntraAuthRateLimiterExtensions"/>.
+/// Defaults: 100 req / 60 s / 6-segment sliding window. Cite ASP.NET Core docs:
+/// <see href="https://learn.microsoft.com/aspnet/core/performance/rate-limit"/>.</summary>
+public sealed class EntraAuthRateLimiterOptions
+{
+    public int PermitLimit { get; set; } = 100;
+    public TimeSpan Window { get; set; } = TimeSpan.FromSeconds(60);
+    public int SegmentsPerWindow { get; set; } = 6;
+}

--- a/src/Ftgo.Auth/EntraAuthSecurityHeadersExtensions.cs
+++ b/src/Ftgo.Auth/EntraAuthSecurityHeadersExtensions.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace Ftgo.Auth;
+
+/// <summary>Default security response headers for an API surface (no HTML, no inline scripts, no embedding).
+/// Doctrine: every response must declare its security posture explicitly — never rely on browser defaults.
+/// Mirrors the OWASP Secure Headers Project recommendations for a JSON API
+/// (<see href="https://owasp.org/www-project-secure-headers/"/>).</summary>
+/// <remarks>
+/// <para>Headers applied:</para>
+/// <list type="bullet">
+///   <item><c>Strict-Transport-Security</c> — 1 year, includeSubDomains, preload (HSTS, RFC 6797).</item>
+///   <item><c>X-Content-Type-Options: nosniff</c> — disables MIME sniffing.</item>
+///   <item><c>X-Frame-Options: DENY</c> — no embedding (also covered by CSP <c>frame-ancestors</c>).</item>
+///   <item><c>Referrer-Policy: no-referrer</c> — APIs never need to leak Referer.</item>
+///   <item><c>Permissions-Policy</c> — disables every browser feature; APIs don't use them.</item>
+///   <item><c>Content-Security-Policy</c> — <c>default-src 'none'; frame-ancestors 'none'</c> (no script/style/image surfaces on a JSON API).</item>
+///   <item><c>Cache-Control: no-store</c> — auth-bearing responses must not be cached.</item>
+/// </list>
+/// <para>Hosts that serve HTML (BFF + Scalar UI) should override CSP after calling this middleware
+/// or pass <see cref="EntraAuthSecurityHeaderOptions.ContentSecurityPolicy"/> with a stricter HTML-friendly value.</para>
+/// </remarks>
+public static class EntraAuthSecurityHeadersExtensions
+{
+    /// <summary>Adds the default API security headers middleware. Call BEFORE <c>UseAuthentication</c>
+    /// so even error responses on the auth path carry the headers.</summary>
+    public static IApplicationBuilder UseEntraAuthSecurityHeaders(
+        this IApplicationBuilder app,
+        EntraAuthSecurityHeaderOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        var opts = options ?? new EntraAuthSecurityHeaderOptions();
+        return app.Use(async (ctx, next) =>
+        {
+            var headers = ctx.Response.Headers;
+            ctx.Response.OnStarting(() =>
+            {
+                headers[HeaderNames.StrictTransportSecurity] = opts.StrictTransportSecurity;
+                headers[HeaderNames.XContentTypeOptions] = "nosniff";
+                headers[HeaderNames.XFrameOptions] = "DENY";
+                headers["Referrer-Policy"] = "no-referrer";
+                headers["Permissions-Policy"] = opts.PermissionsPolicy;
+                headers[HeaderNames.ContentSecurityPolicy] = opts.ContentSecurityPolicy;
+                headers[HeaderNames.CacheControl] = "no-store";
+                headers["X-Permitted-Cross-Domain-Policies"] = "none";
+                return Task.CompletedTask;
+            });
+            await next();
+        });
+    }
+}
+
+/// <summary>Knobs for <see cref="EntraAuthSecurityHeadersExtensions.UseEntraAuthSecurityHeaders"/>.</summary>
+public sealed class EntraAuthSecurityHeaderOptions
+{
+    /// <summary>HSTS header value. Default 1 year + includeSubDomains + preload (per RFC 6797 §6.1).</summary>
+    public string StrictTransportSecurity { get; init; } = "max-age=31536000; includeSubDomains; preload";
+
+    /// <summary>CSP value. Default <c>default-src 'none'; frame-ancestors 'none'</c> — appropriate for a JSON API.
+    /// HTML hosts (BFF, Scalar UI) should override.</summary>
+    public string ContentSecurityPolicy { get; init; } = "default-src 'none'; frame-ancestors 'none'";
+
+    /// <summary>Permissions-Policy value. Default disables all browser-side capabilities.</summary>
+    public string PermissionsPolicy { get; init; } =
+        "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
+}

--- a/src/Ftgo.Auth/HealthChecksExtensions.cs
+++ b/src/Ftgo.Auth/HealthChecksExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -16,9 +17,10 @@ namespace Ftgo.Auth;
 /// </summary>
 public static class HealthChecksExtensions
 {
-    /// <summary>Maps <c>/health/live</c> (always-200 once the process started) and <c>/health/ready</c>
-    /// (200 only when all checks tagged <c>ready</c> pass). Container Apps / K8s probes should hit these
-    /// instead of a single combined <c>/health</c>.</summary>
+    /// <summary>Maps <c>/health/live</c>, <c>/health/ready</c>, and <c>/health/startup</c>.
+    /// Container Apps / K8s probes should hit these instead of a single combined <c>/health</c>:
+    /// startup-probe → liveness-probe → readiness-probe (per Kubernetes
+    /// <see href="https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/">probe doc</see>).</summary>
     public static IEndpointRouteBuilder MapEntraAuthHealthChecks(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
@@ -26,13 +28,39 @@ public static class HealthChecksExtensions
         endpoints.MapHealthChecks("/health/live", new HealthCheckOptions
         {
             Predicate = static _ => false,
+            ResponseWriter = WriteJsonResponse,
         }).AllowAnonymous();
 
         endpoints.MapHealthChecks("/health/ready", new HealthCheckOptions
         {
             Predicate = static check => check.Tags.Contains("ready"),
+            ResponseWriter = WriteJsonResponse,
+        }).AllowAnonymous();
+
+        // Startup checks are tagged "startup". Once startup checks pass, the platform stops
+        // hitting this endpoint and switches to liveness + readiness for the rest of the pod's life.
+        endpoints.MapHealthChecks("/health/startup", new HealthCheckOptions
+        {
+            Predicate = static check => check.Tags.Contains("startup"),
+            ResponseWriter = WriteJsonResponse,
         }).AllowAnonymous();
 
         return endpoints;
+    }
+
+    private static Task WriteJsonResponse(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "application/json; charset=utf-8";
+        var payload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            status = report.Status.ToString(),
+            checks = report.Entries.Select(e => new
+            {
+                name = e.Key,
+                status = e.Value.Status.ToString(),
+                tags = e.Value.Tags,
+            }),
+        });
+        return context.Response.WriteAsync(payload);
     }
 }

--- a/src/Ftgo.Orders.Api/Program.cs
+++ b/src/Ftgo.Orders.Api/Program.cs
@@ -19,11 +19,17 @@ builder.Services.AddAuthorization(o =>
     o.AddAppPolicy(OrdersAuthorizationPolicies.App, "Orders.Process");
 });
 
+builder.Services.AddEntraAuthRateLimiter();
+builder.Services.AddEntraAuthForwardedHeaders();
+
 var app = builder.Build();
+app.UseForwardedHeaders();
+app.UseEntraAuthSecurityHeaders();
 app.UseEntraAuthProblemDetails();
 app.UseAuthentication();
 app.UseAuthorization();
-app.MapControllers();
+app.UseRateLimiter();
+app.MapControllers().RequireRateLimiting(EntraAuthRateLimiterExtensions.DefaultPolicyName);
 app.MapOpenApi().AllowAnonymous();
 app.MapScalarApiReference().AllowAnonymous();
 app.MapEntraAuthHealthChecks();

--- a/src/Ftgo.Restaurants.Api/Program.cs
+++ b/src/Ftgo.Restaurants.Api/Program.cs
@@ -9,11 +9,17 @@ builder.Services.AddOpenApi();
 builder.Services.AddControllers();
 builder.Services.AddHealthChecks();
 
+builder.Services.AddEntraAuthRateLimiter();
+builder.Services.AddEntraAuthForwardedHeaders();
+
 var app = builder.Build();
+app.UseForwardedHeaders();
+app.UseEntraAuthSecurityHeaders();
 app.UseEntraAuthProblemDetails();
 app.UseAuthentication();
 app.UseAuthorization();
-app.MapControllers();
+app.UseRateLimiter();
+app.MapControllers().RequireRateLimiting(EntraAuthRateLimiterExtensions.DefaultPolicyName);
 app.MapOpenApi().AllowAnonymous();
 app.MapScalarApiReference().AllowAnonymous();
 app.MapEntraAuthHealthChecks();

--- a/tests/Ftgo.Auth.Tests/EntraAuthRateLimiterTests.cs
+++ b/tests/Ftgo.Auth.Tests/EntraAuthRateLimiterTests.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using System.Security.Claims;
+using Ftgo.Auth;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Ftgo.Auth.Tests;
+
+public sealed class EntraAuthRateLimiterTests
+{
+    [Fact]
+    public async Task Default_policy_allows_requests_under_limit()
+    {
+        using var host = await BuildHostAsync(permitLimit: 5);
+        using var client = host.GetTestClient();
+
+        for (var i = 0; i < 5; i++)
+        {
+            var response = await client.GetAsync(new Uri("/", UriKind.Relative), TestContext.Current.CancellationToken);
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+    }
+
+    [Fact]
+    public async Task Default_policy_returns_429_with_retry_after_when_over_limit()
+    {
+        using var host = await BuildHostAsync(permitLimit: 2);
+        using var client = host.GetTestClient();
+
+        await client.GetAsync(new Uri("/", UriKind.Relative), TestContext.Current.CancellationToken);
+        await client.GetAsync(new Uri("/", UriKind.Relative), TestContext.Current.CancellationToken);
+        var rejected = await client.GetAsync(new Uri("/", UriKind.Relative), TestContext.Current.CancellationToken);
+
+        rejected.StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
+    }
+
+    [Fact]
+    public void Partition_key_uses_tid_and_oid_when_authenticated()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("tid", "tenant-1"),
+            new Claim("oid", "user-1"),
+        }, authenticationType: "test"));
+
+        var key = EntraAuthRateLimiterExtensions.PartitionKey(ctx);
+
+        key.ShouldBe("u|tenant-1|user-1");
+    }
+
+    [Fact]
+    public void Partition_key_uses_remote_ip_when_unauthenticated()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.7");
+
+        var key = EntraAuthRateLimiterExtensions.PartitionKey(ctx);
+
+        key.ShouldBe("ip|203.0.113.7");
+    }
+
+    private static async Task<IHost> BuildHostAsync(int permitLimit)
+    {
+        var builder = new HostBuilder().ConfigureWebHost(web =>
+        {
+            web.UseTestServer();
+            web.ConfigureServices(services =>
+            {
+                services.AddRouting();
+                services.AddEntraAuthRateLimiter(o =>
+                {
+                    o.PermitLimit = permitLimit;
+                    o.Window = TimeSpan.FromSeconds(60);
+                });
+            });
+            web.Configure(app =>
+            {
+                app.UseRouting();
+                app.UseRateLimiter();
+                app.UseEndpoints(e =>
+                {
+                    e.MapGet("/", (HttpContext _) => Results.Ok("ok"))
+                        .RequireRateLimiting(EntraAuthRateLimiterExtensions.DefaultPolicyName);
+                });
+            });
+        });
+        var host = await builder.StartAsync(TestContext.Current.CancellationToken);
+        return host;
+    }
+}

--- a/tests/Ftgo.Auth.Tests/EntraAuthSecurityHeadersTests.cs
+++ b/tests/Ftgo.Auth.Tests/EntraAuthSecurityHeadersTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using Ftgo.Auth;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Ftgo.Auth.Tests;
+
+public sealed class EntraAuthSecurityHeadersTests
+{
+    [Fact]
+    public async Task Default_headers_present_on_every_response()
+    {
+        using var host = await BuildHostAsync(useDefaults: true);
+        using var client = host.GetTestClient();
+
+        var response = await client.GetAsync(new Uri("/", UriKind.Relative), TestContext.Current.CancellationToken);
+
+        response.Headers.GetValues("Strict-Transport-Security").ShouldContain("max-age=31536000; includeSubDomains; preload");
+        response.Headers.GetValues("X-Content-Type-Options").ShouldContain("nosniff");
+        response.Headers.GetValues("X-Frame-Options").ShouldContain("DENY");
+        response.Headers.GetValues("Referrer-Policy").ShouldContain("no-referrer");
+        response.Headers.GetValues("Permissions-Policy").ShouldNotBeEmpty();
+        response.Headers.GetValues("Content-Security-Policy").ShouldContain("default-src 'none'; frame-ancestors 'none'");
+        response.Headers.GetValues("X-Permitted-Cross-Domain-Policies").ShouldContain("none");
+    }
+
+    [Fact]
+    public async Task Custom_csp_overrides_default()
+    {
+        var customCsp = "default-src 'self'; frame-ancestors 'none'";
+        using var host = await BuildHostAsync(useDefaults: false, customCsp);
+        using var client = host.GetTestClient();
+
+        var response = await client.GetAsync(new Uri("/", UriKind.Relative), TestContext.Current.CancellationToken);
+
+        response.Headers.GetValues("Content-Security-Policy").ShouldContain(customCsp);
+    }
+
+    [Fact]
+    public async Task Cache_control_no_store_on_every_response()
+    {
+        using var host = await BuildHostAsync(useDefaults: true);
+        using var client = host.GetTestClient();
+
+        var response = await client.GetAsync(new Uri("/", UriKind.Relative), TestContext.Current.CancellationToken);
+
+        response.Headers.CacheControl?.NoStore.ShouldBeTrue();
+    }
+
+    private static async Task<IHost> BuildHostAsync(bool useDefaults, string? customCsp = null)
+    {
+        var builder = new HostBuilder().ConfigureWebHost(web =>
+        {
+            web.UseTestServer();
+            web.ConfigureServices(_ => { });
+            web.Configure(app =>
+            {
+                if (useDefaults)
+                {
+                    app.UseEntraAuthSecurityHeaders();
+                }
+                else
+                {
+                    app.UseEntraAuthSecurityHeaders(new EntraAuthSecurityHeaderOptions
+                    {
+                        ContentSecurityPolicy = customCsp!,
+                    });
+                }
+                app.Run(async ctx => await ctx.Response.WriteAsync("ok"));
+            });
+        });
+        var host = await builder.StartAsync(TestContext.Current.CancellationToken);
+        return host;
+    }
+}


### PR DESCRIPTION
Closes the production-readiness gaps surfaced by the prod-ready audit and the holistic critique. Aligns the sample to the same posture dotnet-engineering-guide ch02/ch05 expect from a production API.

## Library additions (src/Ftgo.Auth/)

- **EntraAuthSecurityHeadersExtensions** — `UseEntraAuthSecurityHeaders` adds HSTS (1y/includeSubDomains/preload, RFC 6797), X-Content-Type-Options, X-Frame-Options DENY, Referrer-Policy no-referrer, Permissions-Policy (all browser features off), CSP `default-src 'none'; frame-ancestors 'none'` for JSON APIs (override per host), Cache-Control no-store, X-Permitted-Cross-Domain-Policies none. OWASP Secure Headers Project posture.
- **EntraAuthRateLimiterExtensions** — `AddEntraAuthRateLimiter` wires a sliding-window limiter (default 100 req / 60 s / 6 segments) partitioned by `u|tid|oid` for authenticated callers and `ip|<remote>` for anonymous. RFC 6585 §4 429 + Retry-After on rejection. Per-tenant blast radius bounded.
- **EntraAuthForwardedHeadersExtensions** — `AddEntraAuthForwardedHeaders` honours X-Forwarded-For/Proto/Host so HSTS, redirects, and rate-limiter IP partitions are correct behind ACA's envoy / Front Door / App Gateway.
- **HealthChecksExtensions** — adds `/health/startup` tagged-check endpoint to match the three-endpoint K8s probe contract; live/ready/startup all emit JSON `{status, checks[]}`.

## Wiring (src/Ftgo.{ApiGateway,Orders.Api,Restaurants.Api}/Program.cs)

`UseForwardedHeaders → UseEntraAuthSecurityHeaders → UseEntraAuthProblemDetails → UseAuthentication → UseAuthorization → UseRateLimiter`, then `MapControllers().RequireRateLimiting(...)`.

ApiGateway overrides JSON-API CSP with an HTML-friendly variant for the Scalar UI but keeps `frame-ancestors 'none'`.

## Tests

- EntraAuthSecurityHeadersTests: default headers, custom CSP override, Cache-Control no-store.
- EntraAuthRateLimiterTests: under-limit allowed; 429 returned over limit; partition-key shape.
- **58/58 pass** (51 baseline + 7 new).

## Closes (audit findings)

- prod-ready-audit: security headers (missing → ok), rate limiting (missing → ok), forwarded headers (missing → ok).
- holistic-critique: blocker on three-endpoint health contract (now matches docs); major on baseline response-security headers (now wired); major on rate limiting (now wired).