### PR TITLE
fix: final-verify blockers — Scalar CSP + app-only rate limit + startup probe + doc-truth

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -55,7 +55,7 @@ Specifically:
 These are deliberately out of scope.
 Call them out so readers don't expect them.
 
-- **Not a UI / client-side guide.** Browser sign-in UX, MSAL.js, MSAL on mobile, and Blazor WebAssembly token flows are out of scope; the BFF in the sample uses server-side OIDC ([`docs/sample-setup.md`](./docs/sample-setup.md), [learn.microsoft.com/aspnet/core/blazor/security/server](https://learn.microsoft.com/aspnet/core/blazor/security/server)).
+- **Not a UI / client-side guide.** Browser sign-in UX, MSAL.js, MSAL on mobile, and Blazor WebAssembly token flows are out of scope; the API gateway in the sample validates browser-issued bearer tokens (in-browser Auth Code + PKCE is performed client-side by the Scalar UI), it does not run a server-side cookie session ([`docs/sample-setup.md`](./docs/sample-setup.md), [learn.microsoft.com/aspnet/core/blazor/security/server](https://learn.microsoft.com/aspnet/core/blazor/security/server)).
 - **Not an IdP implementation guide.** This guide consumes Entra; it does not document how to build one (no OpenIddict, no IdentityServer, no Keycloak deployment).
 - **Not Azure AD Connect / hybrid identity.** Directory sync, AD FS migration, password hash sync, and seamless SSO are out of scope ([learn.microsoft.com/entra/identity/hybrid](https://learn.microsoft.com/entra/identity/hybrid)).
 - **Not compliance mapping (FedRAMP / HIPAA / PCI-DSS / SOC 2).** The guide names the Entra-level controls; mapping them to a specific control framework is downstream.

--- a/docs/cost-zero.md
+++ b/docs/cost-zero.md
@@ -37,7 +37,7 @@ Real-world example bills (rough order-of-magnitude, US East, Nov-2024 list price
 
 These are enforced today and **must not** be relaxed without a corresponding cost-budget update:
 
-- **Bicep**: `infra/bicep/modules/aca-app.bicep` defaults `scale.minReplicas=0` and `scale.maxReplicas=1`. Workers (`Ftgo.Kitchen.Worker`) are also `minReplicas=0` — they wake on the next message poll.
+- **Bicep**: `infra/bicep/modules/container-app.bicep` defaults `scale.minReplicas=0` and `scale.maxReplicas=maxReplicas` (parameterized — caller defaults to 1). Workers (`Ftgo.Kitchen.Worker`) are also `minReplicas=0` — they wake on the next message poll.
 - **Bicep**: `infra/bicep/modules/log-analytics.bicep` sets `properties.workspaceCapping.dailyQuotaGb=1` and `retentionInDays=30`.
 - **Bicep**: `infra/bicep/modules/key-vault.bicep` pins `sku.name='standard'` and `enableRbacAuthorization=true`.
 - **Bicep**: no `Microsoft.ContainerRegistry/registries` resource exists — pull comes from GHCR.

--- a/docs/deploy-cloud.md
+++ b/docs/deploy-cloud.md
@@ -44,7 +44,7 @@ What this does (per env, idempotent):
 1. Creates `rg-ftgo-{env}-eastus`.
 1. Creates `ftgo-{env}-cd-mi` user-assigned MI in that RG.
 1. Creates a federated identity credential bound to `repo:OWNER/REPO:environment:{env}`.
-1. Grants Contributor on the resource group; for prod, also User Access Administrator (so it can grant Key Vault RBAC).
+1. Grants Contributor on the resource group; **all envs** also get User Access Administrator (RG-scoped) so the deploy pipeline can assign Key Vault RBAC roles to per-app system-MIs created by `azure.bicep`. The role is RG-scoped — the CD identity cannot assign roles outside its own env's RG.
 1. Creates the GitHub Environment, sets `AZURE_CLIENT_ID` / `AZURE_SUBSCRIPTION_ID` env variables, and (one-time) the repo-scoped `AZURE_TENANT_ID` secret.
 1. For prod, requires a single reviewer before deploys can proceed.
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -75,7 +75,7 @@ The CD identity per env (`ftgo-{env}-cd-mi`) is scoped to its own resource group
 - **Required reviewer** on the `prod` GitHub Environment (configured by `bootstrap-env.sh`).
 - **Concurrency group `prod`** with `cancel-in-progress: false`.
 - **No nightly scale-reset** for prod (the cleanup workflow skips it).
-- **Min replicas = 0** for prod web apps too. To pin one replica to eliminate cold-start, override `cpu`/`memory` and `minReplicas` via the bicepparam file (left as a knob; default is scale-to-zero everywhere for free-tier safety).
+- **Min replicas = 0** for prod web apps too. To pin one replica to eliminate cold-start, raise the `maxReplicas` parameter on `container-app.bicep` *and* edit the module to surface a `minReplicas` parameter (currently hard-coded to `0` to keep idle cost at $0 — see [`docs/cost-zero.md`](cost-zero.md)).
 
 ## Cleanup
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -97,7 +97,7 @@ az lock delete --name ftgo-prod-rg-delete-lock --resource-group rg-ftgo-prod-eas
 ```bash
 gh workflow run cd.yml \
   -f environment=dev \
-  -f image_tag=$(git rev-parse --short HEAD)
+  -f imageTag=$(git rev-parse --short HEAD)
 ```
 
 Smoke-test polls `/health/live` for up to 180s after the deploy

--- a/glossary.md
+++ b/glossary.md
@@ -104,7 +104,7 @@ Optional Entra access-token claim added when configured via an [optional claims 
 
 ### Managed Identity (MI) — system-assigned (SAMI), user-assigned (UAMI)
 
-Azure-platform-issued service principal automatically rotated by the platform, accessible from inside Azure compute via the IMDS endpoint. **System-assigned** is bound 1:1 to a single resource lifecycle; **user-assigned** is a standalone resource that can be attached to many compute instances. Default credential for any code running on Azure compute; this sample uses UAMI uniformly. [Managed identities overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview), [System- vs user-assigned](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/managed-identities-faq).
+Azure-platform-issued service principal automatically rotated by the platform, accessible from inside Azure compute via the IMDS endpoint. **System-assigned** is bound 1:1 to a single resource lifecycle; **user-assigned** is a standalone resource that can be attached to many compute instances. Default credential for any code running on Azure compute. **In this sample**: the four runtime container apps each use a *system-assigned* MI (one per app, lifecycle-bound), while the GitHub Actions CD identity is a *user-assigned* MI per env (`ftgo-{env}-cd-mi`) so it can outlive any single resource. [Managed identities overview](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview), [System- vs user-assigned](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/managed-identities-faq).
 
 ### Microsoft.Identity.Web
 

--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -98,6 +98,18 @@ resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
           ], extraEnvVars)
           probes: enableIngress ? [
             {
+              type: 'Startup'
+              httpGet: {
+                path: '/health/startup'
+                port: 8080
+                scheme: 'HTTP'
+              }
+              initialDelaySeconds: 2
+              periodSeconds:       5
+              timeoutSeconds:      3
+              failureThreshold:    24
+            }
+            {
               type: 'Liveness'
               httpGet: {
                 path: '/health/live'

--- a/src/Ftgo.ApiGateway/Program.cs
+++ b/src/Ftgo.ApiGateway/Program.cs
@@ -23,11 +23,9 @@ builder.Services.AddEntraAuthForwardedHeaders();
 
 var app = builder.Build();
 app.UseForwardedHeaders();
-app.UseEntraAuthSecurityHeaders(new EntraAuthSecurityHeaderOptions
-{
-    // BFF serves the Scalar HTML UI; loosen CSP enough for it to render but keep frame-ancestors locked.
-    ContentSecurityPolicy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'",
-});
+// API gateway serves the Scalar HTML UI; use the Scalar-friendly CSP preset so inline scripts/styles
+// + the in-browser Auth Code + PKCE call to login.microsoftonline.com are not blocked.
+app.UseEntraAuthSecurityHeaders(EntraAuthSecurityHeaderOptions.ScalarFriendly());
 app.UseEntraAuthProblemDetails();
 app.UseAuthentication();
 app.UseAuthorization();

--- a/src/Ftgo.Auth/EntraAuthRateLimiterExtensions.cs
+++ b/src/Ftgo.Auth/EntraAuthRateLimiterExtensions.cs
@@ -16,11 +16,12 @@ namespace Ftgo.Auth;
 /// <remarks>
 /// <para>Default policy <see cref="DefaultPolicyName"/> is a sliding-window limiter:</para>
 /// <list type="bullet">
-///   <item>Authenticated: partition by <c>tid|oid</c> (Entra tenant + object id).</item>
-///   <item>Unauthenticated: partition by <c>ip|&lt;remote-ip&gt;</c>.</item>
-///   <item>100 requests per 60 seconds per partition; 429 with <c>Retry-After</c> on rejection.</item>
+///   <item>Delegated user token: partition by <c>u|tid|oid</c> (Entra tenant + object id), <see cref="EntraAuthRateLimiterOptions.PermitLimit"/> per <see cref="EntraAuthRateLimiterOptions.Window"/>.</item>
+///   <item>App-only token (service principal — `idtyp=app` or `roles` claim with no `scp`): partition by <c>a|tid|appid</c>, <see cref="EntraAuthRateLimiterOptions.AppPermitLimit"/> per window. App-only callers (gateway → downstream API, worker → API) are shared by every end-user behind that service principal, so the ceiling must be much higher than per-user.</item>
+///   <item>Unauthenticated: partition by <c>ip|&lt;remote-ip&gt;</c>, <see cref="EntraAuthRateLimiterOptions.PermitLimit"/> per window.</item>
+///   <item>429 with <c>Retry-After</c> on rejection (RFC 6585 §4 + §3).</item>
 /// </list>
-/// <para>Tune via <see cref="EntraAuthRateLimiterOptions"/>. Cite RFC 6585 §4 for the 429 status semantics.</para>
+/// <para>Tune via <see cref="EntraAuthRateLimiterOptions"/>.</para>
 /// </remarks>
 public static class EntraAuthRateLimiterExtensions
 {
@@ -48,35 +49,35 @@ public static class EntraAuthRateLimiterExtensions
                 return ValueTask.CompletedTask;
             };
 
-            rl.AddPolicy(DefaultPolicyName, ctx => RateLimitPartition.GetSlidingWindowLimiter(
-                partitionKey: PartitionKey(ctx),
-                factory: _ => new SlidingWindowRateLimiterOptions
-                {
-                    PermitLimit = opts.PermitLimit,
-                    Window = opts.Window,
-                    SegmentsPerWindow = opts.SegmentsPerWindow,
-                    QueueLimit = 0,
-                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-                    AutoReplenishment = true,
-                }));
+            rl.AddPolicy(DefaultPolicyName, ctx => BuildPartition(ctx, opts));
 
             rl.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(ctx =>
-                RateLimitPartition.GetSlidingWindowLimiter(
-                    partitionKey: PartitionKey(ctx),
-                    factory: _ => new SlidingWindowRateLimiterOptions
-                    {
-                        PermitLimit = opts.PermitLimit,
-                        Window = opts.Window,
-                        SegmentsPerWindow = opts.SegmentsPerWindow,
-                        QueueLimit = 0,
-                        AutoReplenishment = true,
-                    }));
+                BuildPartition(ctx, opts));
         });
 
         return services;
     }
 
-    internal static string PartitionKey(HttpContext ctx)
+    private static RateLimitPartition<string> BuildPartition(HttpContext ctx, EntraAuthRateLimiterOptions opts)
+    {
+        var (key, isApp) = PartitionKeyAndKind(ctx);
+        var permits = isApp ? opts.AppPermitLimit : opts.PermitLimit;
+        return RateLimitPartition.GetSlidingWindowLimiter(
+            partitionKey: key,
+            factory: _ => new SlidingWindowRateLimiterOptions
+            {
+                PermitLimit = permits,
+                Window = opts.Window,
+                SegmentsPerWindow = opts.SegmentsPerWindow,
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                AutoReplenishment = true,
+            });
+    }
+
+    /// <summary>Test-visible partition key helper. Returns <c>("u|tid|oid", false)</c> for delegated tokens,
+    /// <c>("a|tid|appid", true)</c> for app-only tokens, and <c>("ip|&lt;remote-ip&gt;", false)</c> for anonymous.</summary>
+    internal static (string Key, bool IsApp) PartitionKeyAndKind(HttpContext ctx)
     {
         var user = ctx.User;
         if (user.Identity?.IsAuthenticated == true)
@@ -87,23 +88,54 @@ public static class EntraAuthRateLimiterExtensions
             var tid = user.FindFirstValue("tid")
                        ?? user.FindFirstValue("http://schemas.microsoft.com/identity/claims/tenantid")
                        ?? "unknown-tid";
+
+            // App-only token detection. v2.0 tokens carry idtyp=app for service principals; older flows use
+            // the absence of `scp` together with a `roles` claim. Either signal => bucket by app, not user.
+            // https://learn.microsoft.com/entra/identity-platform/access-token-claims-reference#payload-claims
+            var idtyp = user.FindFirstValue("idtyp");
+            var hasScp = user.FindFirst("scp") is not null
+                         || user.FindFirst("http://schemas.microsoft.com/identity/claims/scope") is not null;
+            var hasRoles = user.FindFirst("roles") is not null
+                           || user.FindFirst(ClaimTypes.Role) is not null;
+            var isApp = string.Equals(idtyp, "app", StringComparison.OrdinalIgnoreCase)
+                        || (!hasScp && hasRoles);
+
+            if (isApp)
+            {
+                var appid = user.FindFirstValue("azp")
+                             ?? user.FindFirstValue("appid")
+                             ?? user.FindFirstValue("http://schemas.microsoft.com/identity/claims/appid")
+                             ?? "unknown-appid";
+                return ($"a|{tid}|{appid}", true);
+            }
+
             var oid = user.FindFirstValue("oid")
                        ?? user.FindFirstValue("http://schemas.microsoft.com/identity/claims/objectidentifier")
                        ?? user.FindFirstValue("sub")
                        ?? "unknown-oid";
-            return $"u|{tid}|{oid}";
+            return ($"u|{tid}|{oid}", false);
         }
         var ip = ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown-ip";
-        return $"ip|{ip}";
+        return ($"ip|{ip}", false);
     }
+
+    /// <summary>Back-compat shim for tests / callers that just want the partition string.</summary>
+    internal static string PartitionKey(HttpContext ctx) => PartitionKeyAndKind(ctx).Key;
 }
 
 /// <summary>Knobs for <see cref="EntraAuthRateLimiterExtensions"/>.
-/// Defaults: 100 req / 60 s / 6-segment sliding window. Cite ASP.NET Core docs:
-/// <see href="https://learn.microsoft.com/aspnet/core/performance/rate-limit"/>.</summary>
+/// Defaults: 100 req / 60 s / 6-segment sliding window for users; 1000 req / 60 s for app-only callers.
+/// Cite ASP.NET Core docs: <see href="https://learn.microsoft.com/aspnet/core/performance/rate-limit"/>.</summary>
 public sealed class EntraAuthRateLimiterOptions
 {
+    /// <summary>Permit ceiling for a delegated-user partition (or anonymous IP partition).</summary>
     public int PermitLimit { get; set; } = 100;
+
+    /// <summary>Permit ceiling for an app-only (service-principal) partition. Defaults to 10× <see cref="PermitLimit"/>
+    /// because a single app identity often fronts many concurrent end-users (gateway → downstream API,
+    /// worker → API). Sharing the per-user budget across them would self-throttle normal traffic.</summary>
+    public int AppPermitLimit { get; set; } = 1000;
+
     public TimeSpan Window { get; set; } = TimeSpan.FromSeconds(60);
     public int SegmentsPerWindow { get; set; } = 6;
 }

--- a/src/Ftgo.Auth/EntraAuthSecurityHeadersExtensions.cs
+++ b/src/Ftgo.Auth/EntraAuthSecurityHeadersExtensions.cs
@@ -59,10 +59,35 @@ public sealed class EntraAuthSecurityHeaderOptions
     public string StrictTransportSecurity { get; init; } = "max-age=31536000; includeSubDomains; preload";
 
     /// <summary>CSP value. Default <c>default-src 'none'; frame-ancestors 'none'</c> — appropriate for a JSON API.
-    /// HTML hosts (BFF, Scalar UI) should override.</summary>
+    /// HTML hosts (BFF, Scalar UI) should call <see cref="ScalarFriendly"/>.</summary>
     public string ContentSecurityPolicy { get; init; } = "default-src 'none'; frame-ancestors 'none'";
 
     /// <summary>Permissions-Policy value. Default disables all browser-side capabilities.</summary>
     public string PermissionsPolicy { get; init; } =
         "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
+
+    /// <summary>CSP preset for hosts that serve the Scalar API-reference UI. Allows the inline scripts/styles
+    /// Scalar emits, the Scalar CDN bundle, and the Microsoft Entra v2.0 OAuth/OIDC endpoints
+    /// (<c>https://login.microsoftonline.com</c>) so the in-browser Auth Code + PKCE flow works.</summary>
+    /// <remarks>
+    /// Sources:
+    /// <list type="bullet">
+    ///   <item>Scalar.AspNetCore CSP guidance — <see href="https://github.com/scalar/scalar/blob/main/documentation/integrations/aspnetcore.md"/>.</item>
+    ///   <item>Microsoft identity platform v2.0 endpoints — <see href="https://learn.microsoft.com/entra/identity-platform/v2-protocols"/>.</item>
+    ///   <item>OWASP CSP cheatsheet — <see href="https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html"/>.</item>
+    /// </list>
+    /// </remarks>
+    public static EntraAuthSecurityHeaderOptions ScalarFriendly() => new()
+    {
+        ContentSecurityPolicy = string.Join(' ',
+            "default-src 'self';",
+            "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;",
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;",
+            "img-src 'self' data: https://cdn.jsdelivr.net;",
+            "font-src 'self' data: https://cdn.jsdelivr.net;",
+            "connect-src 'self' https://login.microsoftonline.com https://cdn.jsdelivr.net;",
+            "frame-ancestors 'none';",
+            "base-uri 'self';",
+            "form-action 'self' https://login.microsoftonline.com"),
+    };
 }

--- a/src/Ftgo.Orders.Api/Program.cs
+++ b/src/Ftgo.Orders.Api/Program.cs
@@ -24,7 +24,7 @@ builder.Services.AddEntraAuthForwardedHeaders();
 
 var app = builder.Build();
 app.UseForwardedHeaders();
-app.UseEntraAuthSecurityHeaders();
+app.UseEntraAuthSecurityHeaders(EntraAuthSecurityHeaderOptions.ScalarFriendly());
 app.UseEntraAuthProblemDetails();
 app.UseAuthentication();
 app.UseAuthorization();

--- a/src/Ftgo.Restaurants.Api/Program.cs
+++ b/src/Ftgo.Restaurants.Api/Program.cs
@@ -14,7 +14,7 @@ builder.Services.AddEntraAuthForwardedHeaders();
 
 var app = builder.Build();
 app.UseForwardedHeaders();
-app.UseEntraAuthSecurityHeaders();
+app.UseEntraAuthSecurityHeaders(EntraAuthSecurityHeaderOptions.ScalarFriendly());
 app.UseEntraAuthProblemDetails();
 app.UseAuthentication();
 app.UseAuthorization();

--- a/tests/Ftgo.Auth.Tests/EntraAuthRateLimiterTests.cs
+++ b/tests/Ftgo.Auth.Tests/EntraAuthRateLimiterTests.cs
@@ -67,6 +67,41 @@ public sealed class EntraAuthRateLimiterTests
         key.ShouldBe("ip|203.0.113.7");
     }
 
+    [Fact]
+    public void Partition_key_buckets_app_only_token_separately_from_user_token()
+    {
+        // App-only token: idtyp=app, no scp, has roles, has azp/appid.
+        var appCtx = new DefaultHttpContext();
+        appCtx.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("tid", "tenant-1"),
+            new Claim("idtyp", "app"),
+            new Claim("azp", "service-app-1"),
+            new Claim("roles", "Orders.Process"),
+        }, authenticationType: "test"));
+
+        var appResult = EntraAuthRateLimiterExtensions.PartitionKeyAndKind(appCtx);
+        appResult.Key.ShouldBe("a|tenant-1|service-app-1");
+        appResult.IsApp.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Partition_key_treats_roles_only_token_as_app_even_without_idtyp()
+    {
+        // Older tokens without idtyp: presence of `roles` and absence of `scp` => app-only.
+        var ctx = new DefaultHttpContext();
+        ctx.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("tid", "tenant-2"),
+            new Claim("appid", "legacy-app"),
+            new Claim("roles", "Restaurants.Read"),
+        }, authenticationType: "test"));
+
+        var (key, isApp) = EntraAuthRateLimiterExtensions.PartitionKeyAndKind(ctx);
+        key.ShouldBe("a|tenant-2|legacy-app");
+        isApp.ShouldBeTrue();
+    }
+
     private static async Task<IHost> BuildHostAsync(int permitLimit)
     {
         var builder = new HostBuilder().ConfigureWebHost(web =>


### PR DESCRIPTION
Final-verify rubber-duck on post-PR-#100 main flagged 2 blockers + 4 majors. This PR resolves all of them.

## Blockers

1. **Scalar broken by default API CSP** — Orders.Api / Restaurants.Api applied `default-src 'none'`; ApiGateway applied `connect-src 'self'` which blocks the in-browser PKCE call to login.microsoftonline.com.
   - New `EntraAuthSecurityHeaderOptions.ScalarFriendly()` preset: explicit CSP allowing Scalar's inline scripts/styles, the `cdn.jsdelivr.net` bundle, and the Microsoft Entra v2.0 OAuth endpoints.
   - Wired into all 3 web apps.

2. **Rate limiter throttles app-only fan-out** — every gateway→Restaurants and worker→Orders call collapsed into one `tid|oid` bucket because all end-user requests share a single service-principal identity.
   - Added app-only token detection (`idtyp=app` OR `roles` present without `scp`) and a separate `a|tid|appid` partition with `AppPermitLimit` (default 10× user limit).
   - +2 tests; 60/60 passing.

## Majors

3. **Startup probe missing in Bicep** — `/health/startup` endpoint existed but ACA never called it. Added Startup probe to `container-app.bicep` (~2min cold-start budget).

4. **Doc-truth false statements**:
   - `SCOPE.md` — 'BFF uses server-side OIDC' (false; PKCE is client-side in Scalar).
   - `glossary.md` MI entry — 'sample uses UAMI uniformly' (false; runtime apps use system-MI, only CD identity is UAMI).
   - `docs/cost-zero.md` — `aca-app.bicep` → `modules/container-app.bicep`.
   - `docs/environments.md` — minReplicas-via-bicepparam claim corrected.
   - `docs/operations.md` — `-f image_tag=` → `-f imageTag=` (matches cd.yml).
   - `docs/deploy-cloud.md` — 'UAA only for prod' → 'all envs' (matches bootstrap.bicep).

## Verification

- `dotnet format` clean
- `dotnet build` clean
- `dotnet test` 60/60 (was 58 — added 2 app-only partition tests)
- markdownlint clean (cli2 v0.18.1, matches CI)
- `bicep build modules/container-app.bicep` clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>